### PR TITLE
feat: add Google Drive integration and meeting recap tooling

### DIFF
--- a/.claude/commands/recap.md
+++ b/.claude/commands/recap.md
@@ -1,0 +1,31 @@
+---
+argument-hint: Event ID or name of a recurring meeting
+description: Fetches Gemini notes from the previous occurrence and inserts a condensed recap into the next occurrence's description
+allowed-tools: [get_meeting_context, edit_event, list_events]
+model: claude-sonnet-4-6
+---
+
+Generate a condensed "previous meeting recap" and insert it into the next occurrence of a recurring meeting.
+
+Steps:
+1. If the user provided a name (not an ID), use list_events with a broad time range to find the event and extract its ID. Use output_format=json to get the raw event IDs.
+2. Call get_meeting_context with the event_id to retrieve:
+   - The Gemini notes from the most recent past occurrence (previous_notes_content)
+   - The next_occurrence_id and next_occurrence_time
+3. If next_occurrence_id is empty, inform the user that no upcoming occurrence was found and show the recap only (do not call edit_event).
+4. Generate a condensed recap from the notes. Target ~150 words, readable in 30 seconds. Format exactly as:
+
+--- Previous Meeting Recap ([Month Day, Year]) ---
+Decisions:
+• [key decision or outcome — max 4 bullets, be specific]
+
+Action Items:
+• [[Owner]] [what they need to do] — include both explicit assignments and implied follow-ups
+• ...
+----------------------------------------------------
+
+5. The recap must stand alone — someone who missed the meeting should understand the state after reading it.
+6. Call edit_event with:
+   - event_id: the next_occurrence_id
+   - description: the recap text. If the existing event description is non-empty, append two newlines then the existing description after the recap block.
+7. Confirm to the user: show the recap, the date of the occurrence it was pulled from, and the date of the occurrence that was updated.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-.PHONY: build clean test install
+.PHONY: build clean test install auth
 
 BINARY_NAME=gcal-mcp-server
 BUILD_DIR=./bin
+
+auth:
+	rm -f token.json
+	go run cmd/server/main.go
 
 build:
 	@mkdir -p $(BUILD_DIR)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -33,8 +33,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Setup Google Drive service
+	driveService, err := auth.GetDriveService()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to retrieve Drive client: %v\n", err)
+		os.Exit(1)
+	}
+
 	// Create calendar client and tools
-	calendarClient := calendar.NewClient(calendarService)
+	calendarClient := calendar.NewClient(calendarService, driveService)
 	calendarTools := calendar.NewCalendarTools(calendarClient)
 
 	// Create MCP server
@@ -47,7 +54,7 @@ func main() {
 
 	// Log server startup to stderr
 	server.LogToStderr("Google Calendar MCP Server starting...")
-	server.LogToStderr("Available tools: create_event, edit_event, delete_event, search_attendees, get_attendee_freebusy, list_events")
+	server.LogToStderr("Available tools: create_event, edit_event, delete_event, search_attendees, get_attendee_freebusy, list_events, get_document")
 
 	// Run the server
 	if err := server.Run(); err != nil {

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/drive/v3"
 )
 
 // AuthError represents an authentication error that may require user action
@@ -124,9 +125,8 @@ func getCredentialPaths() (string, string, error) {
 	return credPath, tokenPath, nil
 }
 
-// GetCalendarService creates and returns a new Google Calendar API service client.
-// It handles OAuth authentication and token management automatically.
-func GetCalendarService() (*calendar.Service, error) {
+// getGoogleHTTPClient returns an authenticated HTTP client with Calendar and Drive scopes.
+func getGoogleHTTPClient() (*http.Client, error) {
 	credPath, tokenPath, err := getCredentialPaths()
 	if err != nil {
 		return nil, fmt.Errorf("unable to determine credential paths: %v", err)
@@ -137,12 +137,18 @@ func GetCalendarService() (*calendar.Service, error) {
 		return nil, fmt.Errorf("unable to read client secret file from %s: %v", credPath, err)
 	}
 
-	config, err := google.ConfigFromJSON(b, calendar.CalendarScope)
+	config, err := google.ConfigFromJSON(b, calendar.CalendarScope, drive.DriveReadonlyScope)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse client secret file to config: %v", err)
 	}
 
-	client, err := getClient(config, tokenPath)
+	return getClient(config, tokenPath)
+}
+
+// GetCalendarService creates and returns a new Google Calendar API service client.
+// It handles OAuth authentication and token management automatically.
+func GetCalendarService() (*calendar.Service, error) {
+	client, err := getGoogleHTTPClient()
 	if err != nil {
 		return nil, err
 	}
@@ -150,6 +156,21 @@ func GetCalendarService() (*calendar.Service, error) {
 	srv, err := calendar.New(client)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve Calendar client: %v", err)
+	}
+
+	return srv, nil
+}
+
+// GetDriveService creates and returns a new Google Drive API service client.
+func GetDriveService() (*drive.Service, error) {
+	client, err := getGoogleHTTPClient()
+	if err != nil {
+		return nil, err
+	}
+
+	srv, err := drive.New(client)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve Drive client: %v", err)
 	}
 
 	return srv, nil

--- a/internal/calendar/client.go
+++ b/internal/calendar/client.go
@@ -18,23 +18,28 @@ package calendar
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/googleapi"
 )
 
 type Client struct {
-	service        *calendar.Service
+	service         *calendar.Service
+	driveService    *drive.Service
 	cachedUserEmail string // cached to avoid repeated API calls
 }
 
-// NewClient creates a new Calendar API client with the given Google Calendar service.
-func NewClient(service *calendar.Service) *Client {
+// NewClient creates a new Calendar API client with the given Google Calendar and Drive services.
+func NewClient(service *calendar.Service, driveService *drive.Service) *Client {
 	return &Client{
-		service: service,
+		service:      service,
+		driveService: driveService,
 	}
 }
 
@@ -158,6 +163,7 @@ type ListEventsParams struct {
 	OrderBy         string    `json:"order_by,omitempty"`
 	ShowDeclined    bool      `json:"show_declined,omitempty"`    // Include declined events in overlap detection
 	DetectOverlaps  bool      `json:"detect_overlaps,omitempty"`  // Enable overlap detection
+	Query           string    `json:"query,omitempty"`            // Free-text search query
 }
 
 // EventWithOverlap wraps a calendar.Event with overlap detection information
@@ -603,8 +609,89 @@ func (c *Client) GetEvent(calendarID, eventID string) (*calendar.Event, error) {
 
 	// Get event with complete attendee information including response status and color
 	getCall := c.service.Events.Get(calendarID, eventID).
-		Fields(googleapi.Field("id,summary,description,location,start,end,attendees(email,displayName,responseStatus),conferenceData,creator,organizer,colorId"))
+		Fields(googleapi.Field(eventDetailFields))
 	return getCall.Do()
+}
+
+// eventDetailFields is the shared field selector used by GetEvent and GetRecurringOccurrences
+// to return a consistent, complete event detail set.
+const eventDetailFields = "id,summary,description,location,start,end,attendees(email,displayName,responseStatus),conferenceData,creator,organizer,colorId,attachments,recurringEventId,status"
+
+// GetRecurringOccurrencesParams holds parameters for listing instances of a recurring event.
+type GetRecurringOccurrencesParams struct {
+	CalendarID  string
+	EventID     string // base recurring event ID, or an instance ID (suffix will be stripped)
+	PastCount   int    // number of past occurrences to return (default 5)
+	FutureCount int    // number of upcoming occurrences to return (default 3)
+}
+
+// stripRecurringInstanceSuffix removes the _YYYYMMDD or _YYYYMMDDTHHMMSSZ suffix
+// from a recurring event instance ID to get the base series ID.
+var recurringInstanceSuffixRe = regexp.MustCompile(`_\d{8}(T\d{6}Z)?$`)
+
+func stripRecurringInstanceSuffix(id string) string {
+	return recurringInstanceSuffixRe.ReplaceAllString(id, "")
+}
+
+// GetRecurringOccurrences returns past and upcoming instances of a recurring event series.
+// It returns (past, upcoming, error). Past is ordered oldest-first; upcoming is ordered
+// soonest-first.
+func (c *Client) GetRecurringOccurrences(params GetRecurringOccurrencesParams) ([]*calendar.Event, []*calendar.Event, error) {
+	if params.CalendarID == "" {
+		params.CalendarID = "primary"
+	}
+	if params.PastCount == 0 {
+		params.PastCount = 5
+	}
+	if params.FutureCount == 0 {
+		params.FutureCount = 3
+	}
+
+	baseID := stripRecurringInstanceSuffix(params.EventID)
+	now := time.Now()
+	fields := googleapi.Field("items("+eventDetailFields+"),nextPageToken")
+
+	// --- Past occurrences ---
+	// Look back up to 2 years; paginate to collect all instances in that window
+	// then take the most recent PastCount.
+	pastTimeMin := now.AddDate(-2, 0, 0)
+	var allPast []*calendar.Event
+	pastCall := c.service.Events.Instances(params.CalendarID, baseID).
+		TimeMin(pastTimeMin.Format(time.RFC3339)).
+		TimeMax(now.Format(time.RFC3339)).
+		MaxResults(250).
+		Fields(fields)
+	for {
+		page, err := pastCall.Do()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get past occurrences: %v", err)
+		}
+		allPast = append(allPast, page.Items...)
+		if page.NextPageToken == "" {
+			break
+		}
+		pastCall = pastCall.PageToken(page.NextPageToken)
+	}
+	// Take the most recent PastCount (list is in ascending startTime order)
+	if len(allPast) > params.PastCount {
+		allPast = allPast[len(allPast)-params.PastCount:]
+	}
+
+	// --- Upcoming occurrences ---
+	upcomingCall := c.service.Events.Instances(params.CalendarID, baseID).
+		TimeMin(now.Format(time.RFC3339)).
+		MaxResults(int64(params.FutureCount)).
+		Fields(fields)
+	upcomingPage, err := upcomingCall.Do()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get upcoming occurrences: %v", err)
+	}
+	upcoming := upcomingPage.Items
+	if len(upcoming) > params.FutureCount {
+		upcoming = upcoming[:params.FutureCount]
+	}
+
+	return allPast, upcoming, nil
 }
 
 // SearchAttendees performs a simplified attendee search based on email validation.
@@ -694,6 +781,10 @@ func (c *Client) ListEvents(params ListEventsParams) (*calendar.Events, error) {
 		call = call.OrderBy(params.OrderBy)
 	} else {
 		call = call.OrderBy("startTime") // Default ordering
+	}
+
+	if params.Query != "" {
+		call = call.Q(params.Query)
 	}
 
 	events, err := call.Do()
@@ -1037,4 +1128,104 @@ func parseEventTimes(event *calendar.Event) (time.Time, time.Time, bool, error) 
 func eventsOverlap(start1, end1, start2, end2 time.Time) bool {
 	// Events overlap if one starts before the other ends and vice versa
 	return start1.Before(end2) && start2.Before(end1)
+}
+
+// GetDocumentParams represents parameters for retrieving a Google Drive document.
+type GetDocumentParams struct {
+	FileID string // raw file ID or a Google Docs/Drive URL
+}
+
+// parseFileID extracts a Drive file ID from a Google Docs/Drive URL, or returns the
+// input unchanged if it looks like a raw file ID already.
+func parseFileID(input string) string {
+	re := regexp.MustCompile(`/d/([a-zA-Z0-9_-]+)`)
+	if m := re.FindStringSubmatch(input); len(m) > 1 {
+		return m[1]
+	}
+	return input
+}
+
+type GetMeetingContextParams struct {
+	CalendarID string // defaults to "primary"
+	EventID    string // instance or recurring event ID
+}
+
+type MeetingContextResult struct {
+	PreviousOccurrenceID   string `json:"previous_occurrence_id"`
+	PreviousOccurrenceTime string `json:"previous_occurrence_time"`
+	PreviousNotesContent   string `json:"previous_notes_content"`
+	NextOccurrenceID       string `json:"next_occurrence_id"`
+	NextOccurrenceTime     string `json:"next_occurrence_time"`
+}
+
+// GetMeetingContext finds the most recent past occurrence with Gemini notes and the next
+// upcoming occurrence for a recurring event. It returns the notes content and the next
+// occurrence's event ID so a recap can be inserted into that instance's description.
+func (c *Client) GetMeetingContext(params GetMeetingContextParams) (*MeetingContextResult, error) {
+	if params.CalendarID == "" {
+		params.CalendarID = "primary"
+	}
+	past, upcoming, err := c.GetRecurringOccurrences(GetRecurringOccurrencesParams{
+		CalendarID:  params.CalendarID,
+		EventID:     params.EventID,
+		PastCount:   10,
+		FutureCount: 1,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the most recent past occurrence with a Gemini Notes attachment (search newest-first)
+	var prevEvent *calendar.Event
+	var geminiFileID string
+	for i := len(past) - 1; i >= 0; i-- {
+		for _, att := range past[i].Attachments {
+			if att.MimeType == "application/vnd.google-apps.document" &&
+				strings.Contains(strings.ToLower(att.Title), "gemini") {
+				prevEvent = past[i]
+				geminiFileID = att.FileId
+				break
+			}
+		}
+		if prevEvent != nil {
+			break
+		}
+	}
+	if prevEvent == nil {
+		return nil, fmt.Errorf("no past occurrence with Gemini notes found")
+	}
+
+	notes, err := c.GetDocument(GetDocumentParams{FileID: geminiFileID})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Gemini notes: %v", err)
+	}
+
+	result := &MeetingContextResult{
+		PreviousOccurrenceID:   prevEvent.Id,
+		PreviousOccurrenceTime: prevEvent.Start.DateTime,
+		PreviousNotesContent:   notes,
+	}
+	if len(upcoming) > 0 {
+		result.NextOccurrenceID = upcoming[0].Id
+		result.NextOccurrenceTime = upcoming[0].Start.DateTime
+	}
+	return result, nil
+}
+
+// GetDocument exports a Google Doc as Markdown text using the Drive API.
+func (c *Client) GetDocument(params GetDocumentParams) (string, error) {
+	if params.FileID == "" {
+		return "", fmt.Errorf("file_id is required")
+	}
+	fileID := parseFileID(params.FileID)
+	resp, err := c.driveService.Files.Export(fileID, "text/markdown").Download()
+	if err != nil {
+		return "", fmt.Errorf("failed to export document: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read document body: %v", err)
+	}
+	return string(body), nil
 }

--- a/internal/calendar/tools.go
+++ b/internal/calendar/tools.go
@@ -432,6 +432,35 @@ func (ct *CalendarTools) GetTools() []mcp.Tool {
 			},
 		},
 		{
+			Name:        "list_event_occurrences",
+			Description: "List past and upcoming occurrences of a recurring calendar event series. Provide the recurring event ID (or any instance ID) to retrieve the full event detail set for each occurrence, including attachments such as meeting notes.",
+			InputSchema: mcp.ToolSchema{
+				Type: "object",
+				Properties: map[string]interface{}{
+					"event_id": map[string]interface{}{
+						"type":        "string",
+						"description": "The recurring event series ID, or any instance ID from the series (the instance suffix will be stripped automatically) (REQUIRED)",
+					},
+					"calendar_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Calendar ID (defaults to 'primary')",
+						"default":     "primary",
+					},
+					"past_count": map[string]interface{}{
+						"type":        "integer",
+						"description": "Number of past occurrences to return (defaults to 5)",
+						"default":     5,
+					},
+					"future_count": map[string]interface{}{
+						"type":        "integer",
+						"description": "Number of upcoming occurrences to return (defaults to 3)",
+						"default":     3,
+					},
+				},
+				Required: []string{"event_id"},
+			},
+		},
+		{
 			Name:        "list_events",
 			Description: "List calendar events with comprehensive filtering options. Supports predefined time filters (today, this_week, next_week) and custom time ranges.",
 			InputSchema: mcp.ToolSchema{
@@ -493,8 +522,44 @@ func (ct *CalendarTools) GetTools() []mcp.Tool {
 						"enum":        []string{"text", "json"},
 						"default":     "text",
 					},
+					"query": map[string]interface{}{
+						"type":        "string",
+						"description": "Free-text search query to filter events by title, description, location, or attendees (optional)",
+					},
 				},
 				Required: []string{},
+			},
+		},
+		{
+			Name:        "get_document",
+			Description: "Retrieve a Google Doc as Markdown text. Accepts a raw file ID or a full Google Docs/Drive URL (e.g. from a calendar event attachment).",
+			InputSchema: mcp.ToolSchema{
+				Type: "object",
+				Properties: map[string]interface{}{
+					"file_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Google Drive file ID or full Google Docs URL",
+					},
+				},
+				Required: []string{"file_id"},
+			},
+		},
+		{
+			Name:        "get_meeting_context",
+			Description: "For a recurring event, retrieves the Gemini notes from the most recent past occurrence and the event ID of the next upcoming occurrence. Use the returned next_occurrence_id with edit_event to insert a recap into the next meeting's description (patching an instance ID only affects that one occurrence, not the series).",
+			InputSchema: mcp.ToolSchema{
+				Type: "object",
+				Properties: map[string]interface{}{
+					"event_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Event ID of any occurrence or the recurring series ID",
+					},
+					"calendar_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Calendar ID (defaults to 'primary')",
+					},
+				},
+				Required: []string{"event_id"},
 			},
 		},
 	}
@@ -517,8 +582,14 @@ func (ct *CalendarTools) HandleTool(name string, arguments map[string]interface{
 		return ct.handleSearchAttendees(arguments)
 	case "get_attendee_freebusy":
 		return ct.handleGetAttendeeFreeBusy(arguments)
+	case "list_event_occurrences":
+		return ct.handleListEventOccurrences(arguments)
 	case "list_events":
 		return ct.handleListEvents(arguments)
+	case "get_document":
+		return ct.handleGetDocument(arguments)
+	case "get_meeting_context":
+		return ct.handleGetMeetingContext(arguments)
 	default:
 		return nil, fmt.Errorf("unknown tool: %s", name)
 	}
@@ -1132,6 +1203,60 @@ func getIntOrDefault(args map[string]interface{}, key string, defaultValue int) 
 	return defaultValue
 }
 
+func (ct *CalendarTools) handleListEventOccurrences(arguments map[string]interface{}) (*mcp.CallToolResult, error) {
+	eventID, ok := arguments["event_id"].(string)
+	if !ok || eventID == "" {
+		return nil, fmt.Errorf("event_id is required")
+	}
+
+	params := GetRecurringOccurrencesParams{
+		CalendarID:  getStringOrDefault(arguments, "calendar_id", "primary"),
+		EventID:     eventID,
+		PastCount:   getIntOrDefault(arguments, "past_count", 5),
+		FutureCount: getIntOrDefault(arguments, "future_count", 3),
+	}
+
+	past, upcoming, err := ct.client.GetRecurringOccurrences(params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recurring occurrences: %v", err)
+	}
+
+	result := ct.formatRecurringOccurrences(past, upcoming)
+
+	return &mcp.CallToolResult{
+		Content: []mcp.ToolResult{{
+			Type: "text",
+			Text: result,
+		}},
+	}, nil
+}
+
+func (ct *CalendarTools) formatRecurringOccurrences(past, upcoming []*calendar.Event) string {
+	type occurrenceResult struct {
+		Past     []json.RawMessage `json:"past"`
+		Upcoming []json.RawMessage `json:"upcoming"`
+	}
+
+	toRaw := func(events []*calendar.Event) []json.RawMessage {
+		out := make([]json.RawMessage, 0, len(events))
+		for _, e := range events {
+			b, err := json.Marshal(e)
+			if err == nil {
+				out = append(out, json.RawMessage(b))
+			}
+		}
+		return out
+	}
+
+	result := occurrenceResult{
+		Past:     toRaw(past),
+		Upcoming: toRaw(upcoming),
+	}
+
+	b, _ := json.MarshalIndent(result, "", "  ")
+	return string(b)
+}
+
 func (ct *CalendarTools) handleListEvents(arguments map[string]interface{}) (*mcp.CallToolResult, error) {
 	params := ListEventsParams{
 		CalendarID:     getStringOrDefault(arguments, "calendar_id", "primary"),
@@ -1143,6 +1268,7 @@ func (ct *CalendarTools) handleListEvents(arguments map[string]interface{}) (*mc
 		OrderBy:        getStringOrDefault(arguments, "order_by", "startTime"),
 		ShowDeclined:   getBoolOrDefault(arguments, "show_declined", false),
 		DetectOverlaps: getBoolOrDefault(arguments, "detect_overlaps", true),
+		Query:          getStringOrDefault(arguments, "query", ""),
 	}
 
 	outputFormat := getStringOrDefault(arguments, "output_format", "text")
@@ -1300,6 +1426,25 @@ func (ct *CalendarTools) formatEventsJSON(events *calendar.Events, params ListEv
 		// Hangout/Meet link
 		if event.HangoutLink != "" {
 			eventJSON["hangoutLink"] = event.HangoutLink
+		}
+
+		// Recurring event ID (identifies which series this instance belongs to)
+		if event.RecurringEventId != "" {
+			eventJSON["recurringEventId"] = event.RecurringEventId
+		}
+
+		// Attachments (e.g. Gemini Notes links)
+		if len(event.Attachments) > 0 {
+			attachmentsJSON := make([]map[string]interface{}, 0, len(event.Attachments))
+			for _, att := range event.Attachments {
+				attachmentsJSON = append(attachmentsJSON, map[string]interface{}{
+					"title":    att.Title,
+					"fileUrl":  att.FileUrl,
+					"mimeType": att.MimeType,
+					"fileId":   att.FileId,
+				})
+			}
+			eventJSON["attachments"] = attachmentsJSON
 		}
 
 		// Focus time properties
@@ -1517,6 +1662,17 @@ func (ct *CalendarTools) formatSingleEvent(result *strings.Builder, event *calen
 		}
 	}
 
+	// Attachments (e.g. Gemini Notes)
+	if len(event.Attachments) > 0 {
+		for _, att := range event.Attachments {
+			title := att.Title
+			if title == "" {
+				title = "Attachment"
+			}
+			result.WriteString(fmt.Sprintf("📎 **%s:** %s\n", title, att.FileUrl))
+		}
+	}
+
 	// Event type information from extended properties
 	if event.ExtendedProperties != nil && event.ExtendedProperties.Private != nil {
 		if eventType, exists := event.ExtendedProperties.Private["eventType"]; exists && eventType != "" {
@@ -1588,4 +1744,42 @@ func (ct *CalendarTools) formatSingleEvent(result *strings.Builder, event *calen
 	result.WriteString(fmt.Sprintf("%s **Has Overlap:** %t\n", overlapIcon, hasOverlap))
 
 	result.WriteString("\n")
+}
+
+func (ct *CalendarTools) handleGetDocument(arguments map[string]interface{}) (*mcp.CallToolResult, error) {
+	fileID, _ := arguments["file_id"].(string)
+	if fileID == "" {
+		return nil, fmt.Errorf("file_id is required")
+	}
+	content, err := ct.client.GetDocument(GetDocumentParams{FileID: fileID})
+	if err != nil {
+		return nil, err
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.ToolResult{{Type: "text", Text: content}},
+	}, nil
+}
+
+func (ct *CalendarTools) handleGetMeetingContext(arguments map[string]interface{}) (*mcp.CallToolResult, error) {
+	eventID, _ := arguments["event_id"].(string)
+	if eventID == "" {
+		return nil, fmt.Errorf("event_id is required")
+	}
+	calendarID := getStringOrDefault(arguments, "calendar_id", "primary")
+
+	result, err := ct.client.GetMeetingContext(GetMeetingContextParams{
+		CalendarID: calendarID,
+		EventID:    eventID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %v", err)
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.ToolResult{{Type: "text", Text: string(data)}},
+	}, nil
 }


### PR DESCRIPTION
    - Add Drive OAuth scope and GetDriveService alongside existing Calendar auth
    - Add get_document tool to export Google Docs as Markdown via Drive API
    - Add list_event_occurrences tool to paginate recurring event instances
    - Add get_meeting_context tool to find the most recent Gemini notes attachment and next occurrence ID for a recurring event
    - Add /recap slash command that generates a condensed previous-meeting recap and inserts it into the next occurrence's description
    - Expose recurringEventId and attachments in list_events JSON output
    - Add free-text query param to list_events
    - Add make auth target to reset token and re-authenticate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Google Drive support for accessing meeting-related documents.
  * Added free-text search functionality for calendar events.
  * Added recurring event management with occurrence tracking.
  * Added meeting context retrieval that locates associated documents within recurring events.
  * Added document export capability in Markdown format.

* **Chores**
  * Added new authentication workflow to development commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->