### PR TITLE
fix(deps): update Python dependencies and resolve security vulnerabilities

### DIFF
--- a/calender/requirements.txt
+++ b/calender/requirements.txt
@@ -1,2 +1,2 @@
-mcp==1.27.1
+mcp==1.27.1  # TODO(CVE-2025-45768): pyjwt transitive dep has disputed "weak encryption" advisory (PYSEC-2025-183); no fixed version exists upstream; supplier contests the finding
 python-multipart>=0.0.29


### PR DESCRIPTION
## Security audit summary

### CVEs found

| CVE ID | PYSEC ID | Package | Severity | Fixed in | Status |
|--------|----------|---------|----------|----------|--------|
| CVE-2025-45768 | PYSEC-2025-183 | pyjwt (transitive via `mcp`) | High (CVSS 7.0) | No fix available | Documented — supplier disputes finding |

**Details on PYSEC-2025-183:**
- Reported as "weak encryption" in pyjwt v2.10.1 and all versions
- **No fixed version exists upstream** — the entire version history is listed as affected
- The PyJWT supplier [disputes the finding](https://github.com/jpadilla/pyjwt), noting key length is chosen by the consuming application, not the library itself
- `pyjwt` 2.12.1 is already the latest available release; no upgrade path resolves the advisory
- Per audit policy, a `# TODO(CVE-2025-45768)` comment has been added at the dependency site in `requirements.txt`

### Dependencies reviewed

| Package | Role | Version | Status |
|---------|------|---------|--------|
| `mcp` | Direct | 1.27.1 | Already at latest stable |
| `python-multipart` | Direct | ≥0.0.29 (resolved: 0.0.29) | Already at latest stable |
| `pyjwt` | Transitive (via `mcp`) | 2.12.1 | Already at latest stable; no CVE fix available |

No version upgrades were possible — all direct and transitive dependencies are already at their latest stable releases.

### Verification

- [x] `pip-audit`: 1 finding (PYSEC-2025-183 / CVE-2025-45768) — **no fixed version exists**, documented in-file
- [x] Direct dependencies already at latest stable (`mcp==1.27.1`, `python-multipart>=0.0.29`)
- [x] Lint: N/A — no linter configured in project (no `ruff`, `flake8`, `pylint`, or `mypy` config found)
- [x] Tests: 12/12 passing (`pytest calender/`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency with a documented security advisory note. A transitive dependency has a known vulnerability (PYSEC-2025-183) with no upstream fix currently available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jnpacker/gcal-mcp-server/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->