### PR TITLE
feat: add Go and Python linting with auto-installing Makefile targets

### DIFF
--- a/.agent-boss
+++ b/.agent-boss
@@ -1,0 +1,2 @@
+AGENT_NAME=Calendar
+SPACE_NAME="paperwork"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gosimple
+    - stylecheck
+    - misspell
+
+issues:
+  exclude-rules:
+    # Allow fmt.Fprintf(os.Stderr, ...) — required pattern for MCP server logging
+    - linters: [forbidigo]
+      text: "fmt.Fprintf"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# Agent Instructions for gcal-mcp-server
+
+This document provides context, patterns, and conventions for AI agents working in this repository.
+
+## 🏗️ Architecture & Organization
+
+This is a Model Context Protocol (MCP) server written in Go that integrates with Google Calendar and Google Drive APIs. 
+
+### Core Components
+* **`cmd/server/main.go`**: The entry point. Initializes services, registers tools, and starts the MCP server.
+* **`internal/mcp/`**: Implements the Model Context Protocol (JSON-RPC over stdin/stdout).
+* **`internal/calendar/`**: Contains the core logic for Google Calendar API interactions (`client.go`) and the MCP tool definitions (`tools.go`).
+* **`internal/auth/`**: Handles Google OAuth 2.0 authentication and token management.
+* **`scripts/`**: Contains scripts for syncing AI command prompts (`sync-commands.sh`, `sync_commands.py`).
+* **`calender/`**: (Note the spelling) Contains a Python-based Terminal UI for calendar management (`calendar_tui.py`) and its tests.
+
+## 🚀 Essential Commands
+
+The repository uses a `Makefile` for common operations:
+
+* **`make build`**: Compiles the Go binary to `./bin/gcal-mcp-server`.
+* **`make test`**: Runs the Go test suite (`go test ./...`). There are also Python tests in `calender/` that run via `pytest`.
+* **`make dev`**: Runs `fmt`, `vet`, `test`, and `build`.
+* **`make auth`**: Removes the local `token.json` and runs the server to force a new Google OAuth flow.
+* **`make sync-commands`**: Runs the script to synchronize AI prompt files across `.claude`, `.gemini`, and `.cursor` directories.
+
+## ⚠️ Important Patterns & Gotchas
+
+1. **Logging vs. Standard Output (CRITICAL)**
+   * **Never write to `stdout` for logging.** Because this is an MCP server, `stdout` is exclusively reserved for the JSON-RPC protocol messages.
+   * Any debug information, logs, or error messages *must* be written to `os.Stderr`. Use `server.LogToStderr()` or `fmt.Fprintf(os.Stderr, ...)` when adding logs.
+
+2. **Credential Discovery**
+   * The server requires Google OAuth credentials (`credentials.json`) and stores an auth token (`token.json`).
+   * It is designed to find these files at the repository root automatically (detecting `go.mod` or `.git`), with the current working directory as a fallback.
+
+3. **AI Command Synchronization**
+   * Instead of a single system prompt, this project provides tailored command instructions for different AI platforms (Claude, Gemini, Cursor).
+   * These commands live in platform-specific hidden directories (`.claude/commands/`, etc.). 
+   * When modifying commands or prompts, update the source of truth and use `make sync-commands` to propagate changes across platforms.
+
+4. **Typo in Directory Name**
+   * The Python component is located in `calender/`, not `calendar/`. Be careful with path autocomplete.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-.PHONY: build clean test install auth
+.PHONY: build clean test test-go test-python lint lint-go lint-python install auth fmt vet mod-tidy deps dev sync-commands
 
 BINARY_NAME=gcal-mcp-server
 BUILD_DIR=./bin
+
+STATICCHECK := $(HOME)/go/bin/staticcheck
 
 auth:
 	rm -f token.json
@@ -18,8 +20,36 @@ clean:
 	rm -rf $(BUILD_DIR)
 	go clean
 
-test:
+## Go tests
+test-go:
 	go test ./...
+
+## Python TUI tests
+test-python:
+	cd calender && pip install -q -r requirements.txt && pytest . -v
+
+## Run all tests
+test: test-go test-python
+
+## Go linting — go vet + staticcheck (installs staticcheck automatically if missing)
+lint-go:
+	go vet ./...
+	@if [ ! -f "$(STATICCHECK)" ]; then \
+		echo "Installing staticcheck..."; \
+		go install honnef.co/go/tools/cmd/staticcheck@latest; \
+	fi
+	$(STATICCHECK) ./...
+
+## Python linting — installs ruff automatically if missing
+lint-python:
+	@if ! python3 -c "import subprocess; subprocess.run(['ruff','--version'],capture_output=True,check=True)" 2>/dev/null; then \
+		echo "Installing ruff..."; \
+		pip install -q ruff; \
+	fi
+	python3 -m ruff check calender/
+
+## Run all linters
+lint: lint-go lint-python
 
 fmt:
 	go fmt ./...
@@ -33,7 +63,7 @@ mod-tidy:
 deps: mod-tidy
 	go mod download
 
-dev: fmt vet test build
+dev: fmt vet lint test build
 
 sync-commands:
 	./scripts/sync-commands.sh

--- a/calender/calendar_tui.py
+++ b/calender/calendar_tui.py
@@ -7,15 +7,14 @@ Requirements:
     pip install mcp curses-menu
 """
 
-import curses
-import json
+import argparse
 import asyncio
+import curses
+import html
+import json
 import os
 import re
-import html
-from datetime import datetime, timedelta, timezone, date
-from typing import List, Dict, Optional
-import argparse
+from datetime import UTC, date, datetime, timedelta
 
 try:
     from mcp import ClientSession, StdioServerParameters
@@ -29,7 +28,7 @@ except ImportError:
 class CalendarEvent:
     """Represents a calendar event with overlap detection"""
 
-    def __init__(self, event_data: Dict, is_available: bool = False, core_start_hour: int = 9, core_end_hour: int = 17):
+    def __init__(self, event_data: dict, is_available: bool = False, core_start_hour: int = 9, core_end_hour: int = 17):
         self.is_available = is_available
         self.core_start_hour = core_start_hour
         self.core_end_hour = core_end_hour
@@ -128,7 +127,7 @@ class CalendarEvent:
 
         return f"{boxes} Available"
 
-    def _get_response_status(self, event_data: Dict) -> str:
+    def _get_response_status(self, event_data: dict) -> str:
         """Extract response status from event data"""
         # Check if user is an attendee and get their response
         attendees = event_data.get('attendees', [])
@@ -139,7 +138,7 @@ class CalendarEvent:
                 return status
         return event_data.get('responseStatus', 'needsAction')
 
-    def _parse_time(self, time_obj: Dict) -> Optional[datetime]:
+    def _parse_time(self, time_obj: dict) -> datetime | None:
         """Parse datetime from event time object"""
         # Check for dateTime field with non-empty value
         if 'dateTime' in time_obj and time_obj['dateTime']:
@@ -267,7 +266,7 @@ class MCPClient:
 
     def __init__(self, server_path: str):
         self.server_path = server_path
-        self.session: Optional[ClientSession] = None
+        self.session: ClientSession | None = None
         self.stdio_context = None
         self.session_context = None
 
@@ -302,7 +301,7 @@ class MCPClient:
             await self.stdio_context.__aexit__(None, None, None)
             self.stdio_context = None
 
-    async def call_tool(self, tool_name: str, arguments: Dict) -> Dict:
+    async def call_tool(self, tool_name: str, arguments: dict) -> dict:
         """Call an MCP tool and return the result"""
         if not self.session:
             raise RuntimeError("Not connected to MCP server")
@@ -319,7 +318,7 @@ class CalendarTUI:
         self.mcp_client = mcp_client
         self.timezone = timezone
         self.debug = debug
-        self.events: List[CalendarEvent] = []
+        self.events: list[CalendarEvent] = []
         self.current_row = 0
         self.scroll_offset = 0
         self.status_message = ""
@@ -629,7 +628,7 @@ class CalendarTUI:
                     self.loaded_dates.add(current_date)
                 current_date += timedelta(days=1)
 
-    def get_filtered_events(self) -> List[CalendarEvent]:
+    def get_filtered_events(self) -> list[CalendarEvent]:
         """Get events filtered by current display mode, view date, and declined status"""
         view_date = self.current_view_date
         day_start = view_date.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -901,7 +900,7 @@ class CalendarTUI:
 
         # Merge declined events with new_events and sort by start time
         timed_events_combined = new_events + declined_events
-        timed_events_combined.sort(key=lambda e: e.start_time if e.start_time else datetime.min.replace(tzinfo=timezone.utc))
+        timed_events_combined.sort(key=lambda e: e.start_time if e.start_time else datetime.min.replace(tzinfo=UTC))
 
         self.events = all_day_events + events_without_times + timed_events_combined
 
@@ -1571,7 +1570,7 @@ class CalendarTUI:
                         self.recommendations_text = f"❌ Error getting recommendations:\n{error_msg}"
                         self.debug_log(f"Claude /recommend failed: {error_msg}")
 
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 # Only update if we're still the current task
                 if hasattr(self, '_current_recommendations_task_id') and my_task_id == self._current_recommendations_task_id:
                     self.recommendations_text = "❌ Request timed out. Please try again."
@@ -2522,9 +2521,9 @@ class CalendarTUI:
                     if not event.start_time:
                         return False
                     # Convert to UTC for consistent comparison across timezones
-                    event_utc = event.start_time.astimezone(timezone.utc)
-                    range_start_utc = range_start.astimezone(timezone.utc)
-                    range_end_utc = range_end.astimezone(timezone.utc)
+                    event_utc = event.start_time.astimezone(UTC)
+                    range_start_utc = range_start.astimezone(UTC)
+                    range_end_utc = range_end.astimezone(UTC)
                     # Check if event starts within the reload range
                     return range_start_utc <= event_utc < range_end_utc
 

--- a/calender/test_calendar_tui.py
+++ b/calender/test_calendar_tui.py
@@ -6,9 +6,9 @@ This tests the MCP client without requiring a curses terminal
 
 import asyncio
 import json
+import os
 import sys
 from datetime import datetime, timedelta
-import os
 
 # Add parent directory to path to import calendar_tui
 sys.path.insert(0, os.path.dirname(__file__))
@@ -405,7 +405,6 @@ async def test_column_alignment():
     title_padded = f"{title:<35}"
     rsvp = regular_event.get_response_char()
     attendees = regular_event.get_attendee_count()[:14]
-
     print(f"   Day column: '{day:<4}' (4 chars)")
     print(f"   Time column: '{time_str}' (23 chars)")
     print(f"   Event column: '{title_padded}' ({len(title_padded)} chars)")
@@ -436,7 +435,6 @@ async def test_column_alignment():
     title_padded_active = f"{title_active:<34}"
     rsvp_active = active_event.get_response_char()
     attendees_active = active_event.get_attendee_count()[:14]
-
     print(f"   Day column: '{day_active:<4}' (4 chars)")
     print(f"   Time column: '{time_str_active}' (23 chars)")
     print(f"   Event column: '{title_padded_active}' ({len(title_padded_active)} chars, 35 display width)")

--- a/calender/test_filter.py
+++ b/calender/test_filter.py
@@ -3,6 +3,7 @@
 
 from datetime import datetime, timedelta
 
+
 def parse_day_filter(day_str: str) -> tuple:
     """Parse day filter and return (time_filter, time_min, time_max)"""
     # Handle standard filters

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,14 @@
+# Ruff configuration for gcal-mcp-server Python code
+target-version = "py312"
+
+[lint]
+select = [
+    "E",   # pycodestyle errors
+    "F",   # pyflakes
+    "W",   # pycodestyle warnings
+    "I",   # isort
+    "UP",  # pyupgrade
+]
+ignore = [
+    "E501",  # line too long — TUI code has intentionally long format strings
+]


### PR DESCRIPTION
## Summary

- Add `lint-go` Makefile target: runs `go vet ./...` + `staticcheck ./...`, auto-installs staticcheck if missing
- Add `lint-python` Makefile target: runs `ruff check calender/`, auto-installs ruff if missing
- Add combined `lint` target and include linting in the `dev` target
- Add `.golangci.yml` (config scaffold) and `ruff.toml` (Python lint config)
- Fix all pre-existing Python lint violations in `calender/`: bare `except` clauses, unused imports, deprecated `typing.Dict/List/Optional`, unsorted imports, stale f-strings, unused variables

Jira: [ACM-34708](https://redhat.atlassian.net/browse/ACM-34708) | [ACM-34709](https://redhat.atlassian.net/browse/ACM-34709)

## Test plan

- [ ] `make lint-go` passes with no violations
- [ ] `make lint-python` passes with no violations
- [ ] `make lint` runs both
- [ ] On a clean machine without staticcheck/ruff, the targets install the tools automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build/dev workflow with separate Go/Python test and lint targets; updated linter configurations and project lint rules
  * Updated agent and workspace environment settings
  
* **Refactor**
  * Modernized Python type annotations and standardized timezone handling for calendar features

* **Tests**
  * Simplified and reordered test utilities and assertions for calendar UI behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->