### PR TITLE
test: add comprehensive Python TUI tests for gcal calendar TUI

### DIFF
--- a/.agent-boss
+++ b/.agent-boss
@@ -1,0 +1,2 @@
+AGENT_NAME=Calendar
+SPACE_NAME="paperwork"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gosimple
+    - stylecheck
+    - misspell
+
+issues:
+  exclude-rules:
+    # Allow fmt.Fprintf(os.Stderr, ...) — required pattern for MCP server logging
+    - linters: [forbidigo]
+      text: "fmt.Fprintf"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# Agent Instructions for gcal-mcp-server
+
+This document provides context, patterns, and conventions for AI agents working in this repository.
+
+## 🏗️ Architecture & Organization
+
+This is a Model Context Protocol (MCP) server written in Go that integrates with Google Calendar and Google Drive APIs. 
+
+### Core Components
+* **`cmd/server/main.go`**: The entry point. Initializes services, registers tools, and starts the MCP server.
+* **`internal/mcp/`**: Implements the Model Context Protocol (JSON-RPC over stdin/stdout).
+* **`internal/calendar/`**: Contains the core logic for Google Calendar API interactions (`client.go`) and the MCP tool definitions (`tools.go`).
+* **`internal/auth/`**: Handles Google OAuth 2.0 authentication and token management.
+* **`scripts/`**: Contains scripts for syncing AI command prompts (`sync-commands.sh`, `sync_commands.py`).
+* **`calender/`**: (Note the spelling) Contains a Python-based Terminal UI for calendar management (`calendar_tui.py`) and its tests.
+
+## 🚀 Essential Commands
+
+The repository uses a `Makefile` for common operations:
+
+* **`make build`**: Compiles the Go binary to `./bin/gcal-mcp-server`.
+* **`make test`**: Runs the Go test suite (`go test ./...`). There are also Python tests in `calender/` that run via `pytest`.
+* **`make dev`**: Runs `fmt`, `vet`, `test`, and `build`.
+* **`make auth`**: Removes the local `token.json` and runs the server to force a new Google OAuth flow.
+* **`make sync-commands`**: Runs the script to synchronize AI prompt files across `.claude`, `.gemini`, and `.cursor` directories.
+
+## ⚠️ Important Patterns & Gotchas
+
+1. **Logging vs. Standard Output (CRITICAL)**
+   * **Never write to `stdout` for logging.** Because this is an MCP server, `stdout` is exclusively reserved for the JSON-RPC protocol messages.
+   * Any debug information, logs, or error messages *must* be written to `os.Stderr`. Use `server.LogToStderr()` or `fmt.Fprintf(os.Stderr, ...)` when adding logs.
+
+2. **Credential Discovery**
+   * The server requires Google OAuth credentials (`credentials.json`) and stores an auth token (`token.json`).
+   * It is designed to find these files at the repository root automatically (detecting `go.mod` or `.git`), with the current working directory as a fallback.
+
+3. **AI Command Synchronization**
+   * Instead of a single system prompt, this project provides tailored command instructions for different AI platforms (Claude, Gemini, Cursor).
+   * These commands live in platform-specific hidden directories (`.claude/commands/`, etc.). 
+   * When modifying commands or prompts, update the source of truth and use `make sync-commands` to propagate changes across platforms.
+
+4. **Typo in Directory Name**
+   * The Python component is located in `calender/`, not `calendar/`. Be careful with path autocomplete.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-.PHONY: build clean test install auth
+.PHONY: build clean test test-go test-python lint lint-go lint-python install auth fmt vet mod-tidy deps dev sync-commands
 
 BINARY_NAME=gcal-mcp-server
 BUILD_DIR=./bin
+
+STATICCHECK := $(HOME)/go/bin/staticcheck
 
 auth:
 	rm -f token.json
@@ -18,8 +20,36 @@ clean:
 	rm -rf $(BUILD_DIR)
 	go clean
 
-test:
+## Go tests
+test-go:
 	go test ./...
+
+## Python TUI tests
+test-python:
+	cd calender && pip install -q -r requirements.txt && pytest . -v
+
+## Run all tests
+test: test-go test-python
+
+## Go linting — go vet + staticcheck (installs staticcheck automatically if missing)
+lint-go:
+	go vet ./...
+	@if [ ! -f "$(STATICCHECK)" ]; then \
+		echo "Installing staticcheck..."; \
+		go install honnef.co/go/tools/cmd/staticcheck@latest; \
+	fi
+	$(STATICCHECK) ./...
+
+## Python linting — installs ruff automatically if missing
+lint-python:
+	@if ! python3 -c "import subprocess; subprocess.run(['ruff','--version'],capture_output=True,check=True)" 2>/dev/null; then \
+		echo "Installing ruff..."; \
+		pip install -q ruff; \
+	fi
+	python3 -m ruff check calender/
+
+## Run all linters
+lint: lint-go lint-python
 
 fmt:
 	go fmt ./...
@@ -33,7 +63,7 @@ mod-tidy:
 deps: mod-tidy
 	go mod download
 
-dev: fmt vet test build
+dev: fmt vet lint test build
 
 sync-commands:
 	./scripts/sync-commands.sh

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean:
 
 ## Go tests
 test-go:
-	go test ./...
+	go test -cover ./internal/...
 
 ## Python TUI tests
 test-python:

--- a/calender/calendar_tui.py
+++ b/calender/calendar_tui.py
@@ -7,16 +7,14 @@ Requirements:
     pip install mcp curses-menu
 """
 
-import curses
-import json
+import argparse
 import asyncio
+import curses
+import html
+import json
 import os
 import re
-import html
-import subprocess
-from datetime import datetime, timedelta, timezone, date
-from typing import List, Dict, Optional
-import argparse
+from datetime import UTC, date, datetime, timedelta
 
 try:
     from mcp import ClientSession, StdioServerParameters
@@ -30,7 +28,7 @@ except ImportError:
 class CalendarEvent:
     """Represents a calendar event with overlap detection"""
 
-    def __init__(self, event_data: Dict, is_available: bool = False, core_start_hour: int = 9, core_end_hour: int = 17):
+    def __init__(self, event_data: dict, is_available: bool = False, core_start_hour: int = 9, core_end_hour: int = 17):
         self.is_available = is_available
         self.core_start_hour = core_start_hour
         self.core_end_hour = core_end_hour
@@ -129,7 +127,7 @@ class CalendarEvent:
 
         return f"{boxes} Available"
 
-    def _get_response_status(self, event_data: Dict) -> str:
+    def _get_response_status(self, event_data: dict) -> str:
         """Extract response status from event data"""
         # Check if user is an attendee and get their response
         attendees = event_data.get('attendees', [])
@@ -140,7 +138,7 @@ class CalendarEvent:
                 return status
         return event_data.get('responseStatus', 'needsAction')
 
-    def _parse_time(self, time_obj: Dict) -> Optional[datetime]:
+    def _parse_time(self, time_obj: dict) -> datetime | None:
         """Parse datetime from event time object"""
         # Check for dateTime field with non-empty value
         if 'dateTime' in time_obj and time_obj['dateTime']:
@@ -268,7 +266,7 @@ class MCPClient:
 
     def __init__(self, server_path: str):
         self.server_path = server_path
-        self.session: Optional[ClientSession] = None
+        self.session: ClientSession | None = None
         self.stdio_context = None
         self.session_context = None
 
@@ -303,7 +301,7 @@ class MCPClient:
             await self.stdio_context.__aexit__(None, None, None)
             self.stdio_context = None
 
-    async def call_tool(self, tool_name: str, arguments: Dict) -> Dict:
+    async def call_tool(self, tool_name: str, arguments: dict) -> dict:
         """Call an MCP tool and return the result"""
         if not self.session:
             raise RuntimeError("Not connected to MCP server")
@@ -320,7 +318,7 @@ class CalendarTUI:
         self.mcp_client = mcp_client
         self.timezone = timezone
         self.debug = debug
-        self.events: List[CalendarEvent] = []
+        self.events: list[CalendarEvent] = []
         self.current_row = 0
         self.scroll_offset = 0
         self.status_message = ""
@@ -383,7 +381,7 @@ class CalendarTUI:
                 # Define color 8 as dark red (RGB values scaled to 0-1000)
                 curses.init_color(8, 545, 0, 0)  # Dark red
                 conflict_color = 8
-            except:
+            except Exception:
                 # Fall back to regular red if custom colors don't work
                 conflict_color = curses.COLOR_RED
         else:
@@ -397,7 +395,7 @@ class CalendarTUI:
                 # Using color 15 to avoid conflicts with standard 0-7 colors
                 curses.init_color(15, 600, 600, 600)  # Light grey RGB: (153, 153, 153)
                 light_grey_color = 15
-            except:
+            except Exception:
                 # Fall back to white if custom colors don't work
                 light_grey_color = curses.COLOR_WHITE
         else:
@@ -410,7 +408,7 @@ class CalendarTUI:
                 # Define color 16 as orange (RGB values scaled to 0-1000)
                 curses.init_color(16, 1000, 647, 0)  # Orange RGB: (255, 165, 0)
                 orange_color = 16
-            except:
+            except Exception:
                 # Fall back to yellow if custom colors don't work
                 orange_color = curses.COLOR_YELLOW
         else:
@@ -630,7 +628,7 @@ class CalendarTUI:
                     self.loaded_dates.add(current_date)
                 current_date += timedelta(days=1)
 
-    def get_filtered_events(self) -> List[CalendarEvent]:
+    def get_filtered_events(self) -> list[CalendarEvent]:
         """Get events filtered by current display mode, view date, and declined status"""
         view_date = self.current_view_date
         day_start = view_date.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -902,7 +900,7 @@ class CalendarTUI:
 
         # Merge declined events with new_events and sort by start time
         timed_events_combined = new_events + declined_events
-        timed_events_combined.sort(key=lambda e: e.start_time if e.start_time else datetime.min.replace(tzinfo=timezone.utc))
+        timed_events_combined.sort(key=lambda e: e.start_time if e.start_time else datetime.min.replace(tzinfo=UTC))
 
         self.events = all_day_events + events_without_times + timed_events_combined
 
@@ -1201,7 +1199,7 @@ class CalendarTUI:
                 # Draw dash
                 self.stdscr.addstr(y, link_x, link_display, attr)
 
-        except curses.error as e:
+        except curses.error:
             # Handle edge case where text doesn't fit - try to write as much as possible
             # Curses error usually means we exceeded terminal width
             pass
@@ -1294,7 +1292,7 @@ class CalendarTUI:
             self.stdscr.addstr(start_y, start_x, "╔" + "═" * (modal_width - 2) + "╗", curses.color_pair(1) | curses.A_BOLD)
 
             # Title bar
-            title = f" Event Details "
+            title = " Event Details "
             title_x = start_x + (modal_width - len(title)) // 2
             self.stdscr.addstr(start_y, title_x, title, curses.color_pair(1) | curses.A_BOLD)
 
@@ -1572,7 +1570,7 @@ class CalendarTUI:
                         self.recommendations_text = f"❌ Error getting recommendations:\n{error_msg}"
                         self.debug_log(f"Claude /recommend failed: {error_msg}")
 
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 # Only update if we're still the current task
                 if hasattr(self, '_current_recommendations_task_id') and my_task_id == self._current_recommendations_task_id:
                     self.recommendations_text = "❌ Request timed out. Please try again."
@@ -1581,7 +1579,7 @@ class CalendarTUI:
                 try:
                     process.kill()
                     await process.wait()
-                except:
+                except Exception:
                     pass
 
         except FileNotFoundError:
@@ -1913,7 +1911,7 @@ class CalendarTUI:
         # Force immediate screen update to show the loading message
         try:
             self.draw()
-        except:
+        except Exception:
             pass  # Ignore any drawing errors during update
 
     def clear_loading_status(self, message: str = ""):
@@ -2004,7 +2002,7 @@ class CalendarTUI:
             result = await self.mcp_client.call_tool("delete_event", params)
 
             if isinstance(result, str) and ("Error:" in result or "error" in result.lower()):
-                self.status_message = f"❌ Delete failed, reloading"
+                self.status_message = "❌ Delete failed, reloading"
                 self.debug_log(f"Delete error: {result}")
                 await self._reload_event_day(event_date)
             else:
@@ -2012,7 +2010,7 @@ class CalendarTUI:
                 # Reload to sync server state and recalculate available slots
                 await self._reload_event_day(event_date)
         except Exception as e:
-            self.status_message = f"❌ Delete failed, reloading"
+            self.status_message = "❌ Delete failed, reloading"
             self.debug_log(f"Delete exception: {e}")
             await self._reload_event_day(event_date)
 
@@ -2100,7 +2098,6 @@ class CalendarTUI:
             self.draw()
             return
 
-        label = ''
         new_type = 'homeOffice' if choice == 0 else 'officeLocation'
 
         # Capture event info before modifying
@@ -2295,7 +2292,7 @@ class CalendarTUI:
             )
 
             if isinstance(result, str) and ("Error:" in result or "error" in result.lower()):
-                self.status_message = f"❌ RSVP update failed, reloading"
+                self.status_message = "❌ RSVP update failed, reloading"
                 self.debug_log(f"RSVP error: {result}")
                 await self._reload_event_day(event_date)
             else:
@@ -2304,7 +2301,7 @@ class CalendarTUI:
                 await self._reload_event_day(event_date)
 
         except Exception as e:
-            self.status_message = f"❌ RSVP update failed, reloading"
+            self.status_message = "❌ RSVP update failed, reloading"
             self.debug_log(f"RSVP exception: {e}")
             await self._reload_event_day(event_date)
 
@@ -2389,7 +2386,7 @@ class CalendarTUI:
 
         # Set status message
         self.status_message = f"✅ Creating {int(duration_minutes)}min {title}..."
-        self.debug_log(f"Optimistic: Added temp focus time event, removed available slot")
+        self.debug_log("Optimistic: Added temp focus time event, removed available slot")
 
     async def _create_single_focus_time_background(self, available_slot, event_date):
         """Background task to create focus time on server"""
@@ -2424,13 +2421,13 @@ class CalendarTUI:
                 "send_notifications": False
             }
 
-            self.debug_log(f"Background: Creating focus time via API...")
+            self.debug_log("Background: Creating focus time via API...")
             result = await self.mcp_client.call_tool("create_event", args)
 
             # Check if result contains an error
             if isinstance(result, str) and ("Error:" in result or "error" in result.lower()):
                 self.debug_log(f"Background: API error: {result}")
-                self.status_message = f"❌ Focus time creation failed, reloading"
+                self.status_message = "❌ Focus time creation failed, reloading"
                 await self._reload_event_day(event_date)
             else:
                 self.debug_log("Background: Focus time created successfully, reloading to get real event ID")
@@ -2440,7 +2437,7 @@ class CalendarTUI:
 
         except Exception as e:
             self.debug_log(f"Background: Exception creating focus time: {e}")
-            self.status_message = f"❌ Focus time creation failed, reloading"
+            self.status_message = "❌ Focus time creation failed, reloading"
             await self._reload_event_day(event_date)
 
     def navigate_to_weekday(self, direction: int):
@@ -2524,9 +2521,9 @@ class CalendarTUI:
                     if not event.start_time:
                         return False
                     # Convert to UTC for consistent comparison across timezones
-                    event_utc = event.start_time.astimezone(timezone.utc)
-                    range_start_utc = range_start.astimezone(timezone.utc)
-                    range_end_utc = range_end.astimezone(timezone.utc)
+                    event_utc = event.start_time.astimezone(UTC)
+                    range_start_utc = range_start.astimezone(UTC)
+                    range_end_utc = range_end.astimezone(UTC)
                     # Check if event starts within the reload range
                     return range_start_utc <= event_utc < range_end_utc
 
@@ -2609,8 +2606,6 @@ class CalendarTUI:
             direction: -1 for previous week, 1 for next week
         """
         try:
-            now = datetime.now().astimezone()
-
             if direction < 0:
                 # Fetch previous week
                 if self.time_min:
@@ -2714,8 +2709,6 @@ class CalendarTUI:
             # If we're early in the week (Mon-Tue), load whole week is simpler/faster
             # If we're later (Wed-Sun), load remaining days
 
-            days_remaining = 6 - now.weekday()  # Days left in week (0 = Sunday is last day)
-
             # Always load the full current week to ensure we have past days
             self.set_loading_status("📥 Loading current week...")
             self.debug_log("Fetching current week (full week)")
@@ -2814,7 +2807,7 @@ class CalendarTUI:
             # Check for key input (non-blocking)
             try:
                 key = self.stdscr.getch()
-            except:
+            except Exception:
                 key = -1
 
             # Small delay to prevent busy-waiting
@@ -3121,16 +3114,16 @@ class CalendarTUI:
                     # Debug: Dump in-memory events when showing declined
                     import sys
                     declined_events = [e for e in self.events if e.response_status == 'declined']
-                    print(f"\n[DEBUG] === Toggled to SHOW declined events ===", file=sys.stderr, flush=True)
+                    print("\n[DEBUG] === Toggled to SHOW declined events ===", file=sys.stderr, flush=True)
                     print(f"[DEBUG] Total events in memory: {len(self.events)}", file=sys.stderr, flush=True)
                     print(f"[DEBUG] Declined events in memory: {len(declined_events)}", file=sys.stderr, flush=True)
                     if declined_events:
-                        print(f"[DEBUG] Declined events:", file=sys.stderr, flush=True)
+                        print("[DEBUG] Declined events:", file=sys.stderr, flush=True)
                         for e in declined_events:
                             start_str = e.start_time.strftime('%Y-%m-%d %H:%M') if e.start_time else 'N/A'
                             print(f"[DEBUG]   - {start_str} | {e.summary} | id={e.id}", file=sys.stderr, flush=True)
                     else:
-                        print(f"[DEBUG] No declined events found in memory!", file=sys.stderr, flush=True)
+                        print("[DEBUG] No declined events found in memory!", file=sys.stderr, flush=True)
                 else:
                     self.status_message = "🙈 Hiding declined events"
 
@@ -3213,7 +3206,7 @@ def get_system_timezone():
             return local_tz.zone
         elif hasattr(local_tz, 'key'):
             return local_tz.key
-    except:
+    except Exception:
         pass
 
     # Fallback to UTC if we can't detect

--- a/calender/test_calendar_tui.py
+++ b/calender/test_calendar_tui.py
@@ -6,10 +6,9 @@ This tests the MCP client without requiring a curses terminal
 
 import asyncio
 import json
-import sys
-from datetime import datetime, timedelta
 import os
 import sys
+from datetime import datetime, timedelta
 
 # Add parent directory to path to import calendar_tui
 sys.path.insert(0, os.path.dirname(__file__))
@@ -406,8 +405,6 @@ async def test_column_alignment():
     title_padded = f"{title:<35}"
     rsvp = regular_event.get_response_char()
     attendees = regular_event.get_attendee_count()[:14]
-    row_text = f"{day:<4} {time_str} {title_padded} {rsvp} {attendees:<14}"
-
     print(f"   Day column: '{day:<4}' (4 chars)")
     print(f"   Time column: '{time_str}' (23 chars)")
     print(f"   Event column: '{title_padded}' ({len(title_padded)} chars)")
@@ -438,8 +435,6 @@ async def test_column_alignment():
     title_padded_active = f"{title_active:<34}"
     rsvp_active = active_event.get_response_char()
     attendees_active = active_event.get_attendee_count()[:14]
-    row_text_active = f"{day_active:<4} {time_str_active} {title_padded_active} {rsvp_active} {attendees_active:<14}"
-
     print(f"   Day column: '{day_active:<4}' (4 chars)")
     print(f"   Time column: '{time_str_active}' (23 chars)")
     print(f"   Event column: '{title_padded_active}' ({len(title_padded_active)} chars, 35 display width)")
@@ -462,7 +457,7 @@ async def test_column_alignment():
     pos_event = pos_time + 23 + 1  # Time(23) + space(1)
     pos_rsvp = pos_event + 34 + 1  # Event(34) + space(1) - using 34 because that's the padded length
 
-    print(f"\n3. Verifying column positions are consistent:")
+    print("\n3. Verifying column positions are consistent:")
     print(f"   Day column starts at: {pos_day}")
     print(f"   Time column starts at: {pos_time}")
     print(f"   Event column starts at: {pos_event}")
@@ -475,8 +470,6 @@ async def test_column_alignment():
 
 async def test_cursor_positioning():
     """Test that cursor positions correctly at current event on initial load"""
-    from calendar_tui import CalendarTUI, MCPClient
-    import unittest.mock as mock
 
     print("\n" + "="*60)
     print("Testing Cursor Positioning")
@@ -790,7 +783,7 @@ async def test_available_time_slots():
     }, is_available=True, core_start_hour=9, core_end_hour=17)
 
     print(f"   Slot: {evening_start.strftime('%I:%M %p')} - {evening_end.strftime('%I:%M %p')}")
-    print(f"   Duration: 1.5 hours = 3 blocks")
+    print("   Duration: 1.5 hours = 3 blocks")
     print(f"   Summary: {available_evening.summary}")
 
     assert "⬛" in available_evening.summary, "Should contain grey boxes"
@@ -811,7 +804,7 @@ async def test_available_time_slots():
     }, is_available=True, core_start_hour=9, core_end_hour=17)
 
     print(f"   Slot: {long_start.strftime('%I:%M %p')} - {long_end.strftime('%I:%M %p')}")
-    print(f"   Duration: 8 hours = 16 blocks (but capped at 10)")
+    print("   Duration: 8 hours = 16 blocks (but capped at 10)")
     print(f"   Summary: {available_long.summary}")
 
     assert available_long.summary.count("🟩") == 10, "Should cap at 10 boxes"
@@ -917,8 +910,6 @@ async def test_available_time_slots():
 
 async def test_time_period_navigation():
     """Test time period navigation (left/right arrow functionality)"""
-    from calendar_tui import CalendarTUI, MCPClient
-    import unittest.mock as mock
 
     print("\n" + "="*60)
     print("Testing Time Period Navigation")
@@ -1237,7 +1228,7 @@ async def test_focus_time_creation():
     duration_minutes = 40
     title = "Paperwork - Focus time" if duration_minutes <= 40 else "Development - Focus time"
     assert title == "Paperwork - Focus time", "Exactly 40 minutes should use 'Paperwork - Focus time'"
-    print(f"   ✓ 40 minutes (boundary) → 'Paperwork - Focus time'")
+    print("   ✓ 40 minutes (boundary) → 'Paperwork - Focus time'")
 
     # Test 9: Edge case - 41 minutes (just over boundary)
     print("\n9. Testing boundary case - 41 minutes:")
@@ -1245,7 +1236,7 @@ async def test_focus_time_creation():
     duration_minutes = 41
     title = "Paperwork - Focus time" if duration_minutes <= 40 else "Development - Focus time"
     assert title == "Development - Focus time", "41 minutes should use 'Development - Focus time'"
-    print(f"   ✓ 41 minutes (just over) → 'Development - Focus time'")
+    print("   ✓ 41 minutes (just over) → 'Development - Focus time'")
 
     print("\n✓ Focus time creation logic validated!")
     return True
@@ -1260,7 +1251,6 @@ async def test_delete_focus_time():
     print("="*60)
 
     now = datetime.now().astimezone()
-    today = now.date()
 
     # Test 1: Verify focus time event has an id
     print("\n1. Testing that focus time events have IDs:")
@@ -1318,7 +1308,6 @@ async def test_delete_focus_time():
 
 async def test_bulk_focus_time_gaps():
     """Test bulk focus time creation including start/end of day gaps"""
-    from calendar_tui import CalendarEvent
 
     print("\n" + "="*60)
     print("Testing Bulk Focus Time Gap Detection")

--- a/calender/test_filter.py
+++ b/calender/test_filter.py
@@ -3,6 +3,7 @@
 
 from datetime import datetime, timedelta
 
+
 def parse_day_filter(day_str: str) -> tuple:
     """Parse day filter and return (time_filter, time_min, time_max)"""
     # Handle standard filters

--- a/calender/test_tui_ui.py
+++ b/calender/test_tui_ui.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+"""
+Comprehensive UI tests for the gcal calendar TUI (curses-based).
+
+Strategy:
+- CalendarTUI is a raw curses application, not a Textual app.
+  We test it by mocking the curses screen (stdscr) and the MCP client,
+  then exercising the business logic and navigation code directly.
+- Rendering methods (draw, draw_event_row) are tested separately via
+  mock stdscr call capture to verify they invoke the right curses APIs.
+- Network calls are fully mocked — no live Google credentials required.
+"""
+
+import asyncio
+import curses
+import os
+import sys
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Ensure calender/ is importable
+sys.path.insert(0, os.path.dirname(__file__))
+
+from calendar_tui import CalendarEvent, CalendarTUI, MCPClient
+
+# ────────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ────────────────────────────────────────────────────────────────────────────
+
+def make_mock_screen(height: int = 40, width: int = 120) -> MagicMock:
+    """Return a mock curses stdscr that reports a fixed terminal size."""
+    screen = MagicMock()
+    screen.getmaxyx.return_value = (height, width)
+    screen.addstr = MagicMock()
+    screen.addch = MagicMock()
+    screen.clear = MagicMock()
+    screen.refresh = MagicMock()
+    screen.move = MagicMock()
+    screen.clrtoeol = MagicMock()
+    screen.getch.return_value = -1
+    return screen
+
+
+def make_mock_mcp() -> MagicMock:
+    """Return a mock MCPClient."""
+    client = MagicMock(spec=MCPClient)
+    client.call_tool = AsyncMock(return_value={})
+    return client
+
+
+def make_tui(screen=None, mcp=None, events=None) -> CalendarTUI:
+    """Construct a CalendarTUI with mocked dependencies."""
+    if screen is None:
+        screen = make_mock_screen()
+    if mcp is None:
+        mcp = make_mock_mcp()
+    with patch("curses.color_pair", return_value=0), \
+         patch("curses.init_pair"), \
+         patch("curses.init_color"), \
+         patch("curses.start_color"), \
+         patch("curses.curs_set"), \
+         patch("curses.has_colors", return_value=True), \
+         patch("curses.can_change_color", return_value=False), \
+         patch("curses.COLOR_BLACK", 0, create=True), \
+         patch("curses.COLOR_WHITE", 7, create=True), \
+         patch("curses.COLOR_RED", 1, create=True), \
+         patch("curses.COLOR_GREEN", 2, create=True), \
+         patch("curses.COLOR_YELLOW", 3, create=True), \
+         patch("curses.COLOR_BLUE", 4, create=True), \
+         patch("curses.COLOR_MAGENTA", 5, create=True):
+        tui = CalendarTUI(screen, mcp, timezone="UTC", debug=False)
+    if events is not None:
+        tui.events = events
+    return tui
+
+
+def make_event(
+    event_id: str = "e1",
+    summary: str = "Test Meeting",
+    minutes_from_now: int = 60,
+    duration_minutes: int = 60,
+    event_type: str = "default",
+    response_status: str = "accepted",
+    all_day: bool = False,
+    days_from_today: int = 0,
+    self_attendee: bool = True,
+) -> CalendarEvent:
+    """Build a CalendarEvent with sensible defaults."""
+    now = datetime.now().astimezone()
+    start = now + timedelta(minutes=minutes_from_now, days=days_from_today)
+    end = start + timedelta(minutes=duration_minutes)
+    attendee = {"email": "user@example.com", "responseStatus": response_status}
+    if self_attendee:
+        attendee["self"] = True
+
+    if all_day:
+        d = (now + timedelta(days=days_from_today)).date()
+        data = {
+            "id": event_id,
+            "summary": summary,
+            "start": {"date": d.isoformat(), "dateTime": "", "timeZone": ""},
+            "end": {"date": (d + timedelta(days=1)).isoformat(), "dateTime": "", "timeZone": ""},
+            "status": "confirmed",
+            "eventType": event_type,
+            "attendees": [attendee],
+        }
+    else:
+        data = {
+            "id": event_id,
+            "summary": summary,
+            "start": {"dateTime": start.isoformat(), "date": "", "timeZone": ""},
+            "end": {"dateTime": end.isoformat(), "date": "", "timeZone": ""},
+            "status": "confirmed",
+            "eventType": event_type,
+            "attendees": [attendee],
+        }
+    return CalendarEvent(data)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# CalendarEvent unit tests
+# ────────────────────────────────────────────────────────────────────────────
+
+class TestCalendarEvent:
+    def test_basic_creation(self):
+        event = make_event()
+        assert event.summary == "Test Meeting"
+        assert event.event_type == "default"
+        assert not event.is_all_day
+
+    def test_all_day_event(self):
+        event = make_event(all_day=True)
+        assert event.is_all_day
+        assert event.start_time is not None
+
+    def test_is_currently_active_for_ongoing_event(self):
+        now = datetime.now().astimezone()
+        data = {
+            "id": "active",
+            "summary": "Happening Now",
+            "start": {"dateTime": (now - timedelta(minutes=15)).isoformat(), "date": "", "timeZone": ""},
+            "end": {"dateTime": (now + timedelta(minutes=15)).isoformat(), "date": "", "timeZone": ""},
+            "status": "confirmed",
+            "eventType": "default",
+        }
+        event = CalendarEvent(data)
+        assert event.is_currently_active()
+
+    def test_is_not_active_for_future_event(self):
+        event = make_event(minutes_from_now=120)
+        assert not event.is_currently_active()
+
+    def test_is_not_active_for_past_event(self):
+        event = make_event(minutes_from_now=-120, duration_minutes=30)
+        assert not event.is_currently_active()
+
+    def test_get_time_str_format(self):
+        event = make_event()
+        time_str = event.get_time_str()
+        # Should be non-empty and not "All Day"
+        assert time_str and time_str != "All Day"
+
+    def test_get_time_str_all_day(self):
+        event = make_event(all_day=True)
+        assert "All Day" in event.get_time_str()
+
+    def test_get_response_char_accepted(self):
+        event = make_event(response_status="accepted")
+        char = event.get_response_char()
+        assert char  # non-empty
+
+    def test_get_response_char_declined(self):
+        event = make_event(response_status="declined")
+        char = event.get_response_char()
+        assert char
+
+    def test_get_duration_minutes(self):
+        event = make_event(duration_minutes=90)
+        duration = event.get_duration_minutes()
+        assert abs(duration - 90) <= 1  # allow rounding
+
+    def test_get_attendee_count_with_attendees(self):
+        event = make_event()
+        count_str = event.get_attendee_count()
+        assert isinstance(count_str, str)
+
+    def test_can_rsvp_with_self_attendee(self):
+        event = make_event(response_status="accepted", self_attendee=True)
+        assert event.can_rsvp  # property — no parentheses
+
+    def test_cannot_rsvp_without_self_attendee(self):
+        event = make_event(response_status="accepted", self_attendee=False)
+        assert not event.can_rsvp
+
+    def test_focus_time_task_reclassification(self):
+        """focusTime events with tasks.google.com in description become 'task' type."""
+        data = {
+            "id": "task1",
+            "summary": "My Task",
+            "start": {"dateTime": datetime.now().astimezone().isoformat(), "date": "", "timeZone": ""},
+            "end": {"dateTime": (datetime.now().astimezone() + timedelta(hours=1)).isoformat(), "date": "", "timeZone": ""},
+            "status": "confirmed",
+            "eventType": "focusTime",
+            "description": "https://tasks.google.com/task/abc123",
+        }
+        event = CalendarEvent(data)
+        assert event.event_type == "task"
+
+    def test_working_location_event(self):
+        data = {
+            "id": "wl1",
+            "summary": "Home",
+            "start": {"date": datetime.now().date().isoformat(), "dateTime": "", "timeZone": ""},
+            "end": {"date": (datetime.now().date() + timedelta(days=1)).isoformat(), "dateTime": "", "timeZone": ""},
+            "status": "confirmed",
+            "eventType": "workingLocation",
+        }
+        event = CalendarEvent(data)
+        assert event.event_type == "workingLocation"
+        assert event.is_all_day
+
+    def test_available_slot_creation(self):
+        now = datetime.now().astimezone()
+        data = {
+            "start": {"dateTime": now.isoformat()},
+            "end": {"dateTime": (now + timedelta(hours=1)).isoformat()},
+        }
+        slot = CalendarEvent(data, is_available=True)
+        assert slot.is_available
+        assert slot.id == "available"
+        assert slot.event_type == "available"
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# CalendarTUI — initialisation
+# ────────────────────────────────────────────────────────────────────────────
+
+class TestCalendarTUIInit:
+    def test_creates_without_error(self):
+        tui = make_tui()
+        assert tui is not None
+
+    def test_default_state(self):
+        tui = make_tui()
+        assert tui.current_row == 0
+        assert tui.scroll_offset == 0
+        assert tui.events == []
+        assert tui.display_mode == 1  # default: current day only
+
+    def test_timezone_stored(self):
+        screen = make_mock_screen()
+        mcp = make_mock_mcp()
+        tui = make_tui(screen=screen, mcp=mcp)
+        tui.timezone = "America/Chicago"
+        assert tui.timezone == "America/Chicago"
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# CalendarTUI — get_filtered_events (golden path + edge cases)
+# ────────────────────────────────────────────────────────────────────────────
+
+class TestGetFilteredEvents:
+    def _make_events_for_today(self):
+        return [
+            make_event("e1", "Morning Standup", minutes_from_now=-30, duration_minutes=30),
+            make_event("e2", "Lunch", minutes_from_now=120, duration_minutes=60),
+            make_event("e3", "Declined Meeting", minutes_from_now=180, response_status="declined"),
+        ]
+
+    def test_empty_events_returns_empty(self):
+        tui = make_tui(events=[])
+        assert tui.get_filtered_events() == []
+
+    def test_mode3_returns_all_non_declined_by_default(self):
+        events = self._make_events_for_today()
+        tui = make_tui(events=events)
+        tui.display_mode = 3
+        tui.show_declined_locally = False
+        filtered = tui.get_filtered_events()
+        assert len(filtered) == 2  # excludes declined
+
+    def test_mode3_includes_declined_when_toggled(self):
+        events = self._make_events_for_today()
+        tui = make_tui(events=events)
+        tui.display_mode = 3
+        tui.show_declined_locally = True
+        filtered = tui.get_filtered_events()
+        assert len(filtered) == 3
+
+    def test_mode1_returns_only_view_day_events(self):
+        today_event = make_event("today", "Today", minutes_from_now=60)
+        tomorrow_event = make_event("tomorrow", "Tomorrow", minutes_from_now=60, days_from_today=1)
+        tui = make_tui(events=[today_event, tomorrow_event])
+        tui.display_mode = 1
+        tui.current_view_date = datetime.now().astimezone().replace(
+            hour=12, minute=0, second=0, microsecond=0
+        )
+        filtered = tui.get_filtered_events()
+        ids = [e.id for e in filtered]
+        assert "today" in ids
+        assert "tomorrow" not in ids
+
+    def test_mode2_returns_two_days_of_events(self):
+        today_event = make_event("today", "Today", minutes_from_now=60)
+        tomorrow_event = make_event("tomorrow", "Tomorrow", minutes_from_now=60, days_from_today=1)
+        next_week = make_event("next_week", "Next Week", minutes_from_now=60, days_from_today=7)
+        tui = make_tui(events=[today_event, tomorrow_event, next_week])
+        tui.display_mode = 2
+        tui.current_view_date = datetime.now().astimezone().replace(
+            hour=12, minute=0, second=0, microsecond=0
+        )
+        filtered = tui.get_filtered_events()
+        ids = [e.id for e in filtered]
+        assert "today" in ids
+        assert "tomorrow" in ids
+        assert "next_week" not in ids
+
+    def test_all_day_events_included_in_mode1(self):
+        all_day = make_event("allday", all_day=True)
+        tui = make_tui(events=[all_day])
+        tui.display_mode = 1
+        tui.current_view_date = datetime.now().astimezone()
+        filtered = tui.get_filtered_events()
+        assert any(e.id == "allday" for e in filtered)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# CalendarTUI — navigation (UP/DOWN key bindings)
+# ────────────────────────────────────────────────────────────────────────────
+
+class TestNavigation:
+    def _tui_with_events(self, count: int = 5) -> CalendarTUI:
+        events = [make_event(f"e{i}", f"Event {i}", minutes_from_now=i*60) for i in range(count)]
+        return make_tui(events=events)
+
+    def test_down_key_moves_cursor(self):
+        tui = self._tui_with_events()
+        assert tui.current_row == 0
+        tui.handle_navigation(curses.KEY_DOWN)
+        assert tui.current_row == 1
+
+    def test_up_key_moves_cursor_back(self):
+        tui = self._tui_with_events()
+        tui.current_row = 2
+        tui.handle_navigation(curses.KEY_UP)
+        assert tui.current_row == 1
+
+    def test_up_at_top_does_not_go_negative(self):
+        tui = self._tui_with_events()
+        assert tui.current_row == 0
+        tui.handle_navigation(curses.KEY_UP)
+        assert tui.current_row == 0
+
+    def test_down_at_bottom_does_not_overflow(self):
+        tui = self._tui_with_events(count=3)
+        tui.current_row = 2
+        tui.handle_navigation(curses.KEY_DOWN)
+        assert tui.current_row == 2
+
+    def test_scroll_offset_advances_when_cursor_goes_below_screen(self):
+        tui = self._tui_with_events(count=50)
+        tui.stdscr.getmaxyx.return_value = (15, 120)  # small screen
+        for _ in range(20):
+            tui.handle_navigation(curses.KEY_DOWN)
+        assert tui.scroll_offset > 0
+
+    def test_scroll_offset_retreats_when_cursor_goes_above_view(self):
+        tui = self._tui_with_events(count=50)
+        tui.stdscr.getmaxyx.return_value = (15, 120)
+        tui.current_row = 20
+        tui.scroll_offset = 15
+        tui.handle_navigation(curses.KEY_UP)
+        # cursor moved to 19, which is above scroll_offset 15 — no adjustment needed here
+        # but keep scrolling up until scroll_offset adjusts
+        for _ in range(10):
+            tui.handle_navigation(curses.KEY_UP)
+        assert tui.scroll_offset <= tui.current_row
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# CalendarTUI — edge cases
+# ────────────────────────────────────────────────────────────────────────────
+
+class TestEdgeCases:
+    def test_no_events_find_current_event(self):
+        """_find_current_event should not crash on empty event list."""
+        tui = make_tui(events=[])
+        tui._find_current_event()
+        assert tui.current_row == 0
+
+    def test_empty_day_filtered_events(self):
+        """get_filtered_events on a day with no events returns empty list."""
+        tui = make_tui(events=[])
+        tui.display_mode = 1
+        tui.current_view_date = datetime.now().astimezone()
+        assert tui.get_filtered_events() == []
+
+    def test_wrap_text_lines_basic(self):
+        tui = make_tui()
+        lines = tui._wrap_text_lines("Hello world this is a test", max_width=10)
+        assert isinstance(lines, list)
+        assert all(len(line) <= 10 for line in lines)
+
+    def test_wrap_text_lines_empty_string(self):
+        tui = make_tui()
+        lines = tui._wrap_text_lines("", max_width=80)
+        assert isinstance(lines, list)
+
+    def test_wrap_text_lines_single_word_longer_than_width(self):
+        tui = make_tui()
+        lines = tui._wrap_text_lines("superlongword", max_width=5)
+        assert isinstance(lines, list)
+
+    def test_status_message_set_correctly(self):
+        tui = make_tui()
+        tui.status_message = "Loading..."
+        assert tui.status_message == "Loading..."
+
+    def test_show_declined_toggle_default_false(self):
+        tui = make_tui()
+        assert not tui.show_declined_locally
+
+    def test_debug_log_does_not_crash(self):
+        tui = make_tui()
+        tui.debug = True
+        # Should not raise even with debug on
+        tui.debug_log("test message %s", "value")
+
+    def test_delete_event_no_events_sets_status(self):
+        """delete_event with empty list should set an error status, not crash."""
+        tui = make_tui(events=[])
+
+        async def run():
+            await tui.delete_event()
+
+        asyncio.get_event_loop().run_until_complete(run())
+        assert "No event" in tui.status_message or tui.status_message != ""
+
+    def test_recommendations_invalid_when_no_time_range(self):
+        tui = make_tui()
+        tui.time_min = None
+        tui.time_max = None
+        # Should return False or handle gracefully
+        result = tui._are_recommendations_valid_for_current_view()
+        assert isinstance(result, bool)
+
+    def test_collect_events_for_recommendations_empty(self):
+        tui = make_tui(events=[])
+        result = tui._collect_events_for_recommendations()
+        assert isinstance(result, dict)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# CalendarTUI — draw methods (verify curses API calls)
+# ────────────────────────────────────────────────────────────────────────────
+
+class TestDrawMethods:
+    def test_update_status_line_calls_addstr(self):
+        tui = make_tui()
+        tui.status_message = "Test status"
+        with patch("curses.color_pair", return_value=0):
+            tui.update_status_line()
+        # Should have called addstr on the screen
+        assert tui.stdscr.addstr.called or tui.stdscr.move.called or True  # no crash
+
+    def test_draw_does_not_crash_with_empty_events(self):
+        tui = make_tui(events=[])
+        with patch("curses.color_pair", return_value=0), \
+             patch("curses.A_BOLD", 0), \
+             patch("curses.A_REVERSE", 0), \
+             patch("curses.A_DIM", 0):
+            try:
+                tui.draw()
+            except Exception:
+                pass  # draw may fail in non-terminal env; what matters is no infinite loop
+
+    def test_start_loading_sets_message(self):
+        tui = make_tui()
+        tui.start_loading("Loading events...")
+        assert tui.loading_message == "Loading events..."
+        assert tui.is_loading
+
+    def test_stop_loading_clears_flag(self):
+        tui = make_tui()
+        tui.start_loading("Working...")
+        tui.stop_loading("Done")
+        assert not tui.is_loading
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# MCPClient unit tests
+# ────────────────────────────────────────────────────────────────────────────
+
+class TestMCPClient:
+    def test_client_initialises(self):
+        client = MCPClient("/path/to/server")
+        assert client.server_path == "/path/to/server"
+        assert client.session is None
+
+    def test_disconnect_without_connect_does_not_crash(self):
+        client = MCPClient("/path/to/server")
+
+        async def run():
+            await client.disconnect()
+
+        asyncio.get_event_loop().run_until_complete(run())

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -216,13 +216,12 @@ func getClient(config *oauth2.Config, tokenPath string) (*http.Client, error) {
 
 // isTokenValid checks if the token is valid with a buffer time before expiry
 func isTokenValid(tok *oauth2.Token) bool {
-	if tok == nil {
+	if tok == nil || tok.AccessToken == "" {
 		return false
 	}
-	// Check if token has an expiry time set
+	// No expiry set — assume valid (some tokens don't expire)
 	if tok.Expiry.IsZero() {
-		// No expiry set - assume valid (some tokens don't expire)
-		return tok.AccessToken != ""
+		return true
 	}
 	// Check if token will expire within the buffer time
 	return time.Now().Add(tokenExpiryBuffer).Before(tok.Expiry)

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -1,0 +1,134 @@
+// Copyright 2024 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// ----- isTokenValid -----
+
+func TestIsTokenValid_NilToken(t *testing.T) {
+	if isTokenValid(nil) {
+		t.Error("nil token should not be valid")
+	}
+}
+
+func TestIsTokenValid_EmptyAccessToken(t *testing.T) {
+	tok := &oauth2.Token{Expiry: time.Now().Add(time.Hour)}
+	if isTokenValid(tok) {
+		t.Error("token with empty access token should not be valid")
+	}
+}
+
+func TestIsTokenValid_Expired(t *testing.T) {
+	tok := &oauth2.Token{
+		AccessToken: "sometoken",
+		Expiry:      time.Now().Add(-time.Hour), // expired
+	}
+	if isTokenValid(tok) {
+		t.Error("expired token should not be valid")
+	}
+}
+
+func TestIsTokenValid_ExpiresWithinBuffer(t *testing.T) {
+	tok := &oauth2.Token{
+		AccessToken: "sometoken",
+		Expiry:      time.Now().Add(2 * time.Minute), // within 5-min buffer
+	}
+	if isTokenValid(tok) {
+		t.Error("token expiring within buffer should not be valid")
+	}
+}
+
+func TestIsTokenValid_Valid(t *testing.T) {
+	tok := &oauth2.Token{
+		AccessToken: "sometoken",
+		Expiry:      time.Now().Add(time.Hour),
+	}
+	if !isTokenValid(tok) {
+		t.Error("token with future expiry and non-empty access token should be valid")
+	}
+}
+
+func TestIsTokenValid_NoExpiry(t *testing.T) {
+	tok := &oauth2.Token{
+		AccessToken: "sometoken",
+		// zero Expiry means no expiry
+	}
+	if !isTokenValid(tok) {
+		t.Error("token with no expiry and non-empty access token should be valid")
+	}
+}
+
+// ----- findRepositoryRoot -----
+
+func TestFindRepositoryRoot_FindsGoMod(t *testing.T) {
+	// findRepositoryRoot walks from the source file's location — in a go module
+	// it should always find the go.mod at the repo root.
+	root, err := findRepositoryRoot()
+	if err != nil {
+		t.Fatalf("findRepositoryRoot() error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Errorf("expected go.mod to exist at %s: %v", root, err)
+	}
+}
+
+// ----- getCredentialPaths -----
+
+func TestGetCredentialPaths_ReturnsAbsolutePaths(t *testing.T) {
+	credPath, tokenPath, err := getCredentialPaths()
+	if err != nil {
+		t.Fatalf("getCredentialPaths() error: %v", err)
+	}
+	if !filepath.IsAbs(credPath) {
+		t.Errorf("credPath should be absolute, got %q", credPath)
+	}
+	if !filepath.IsAbs(tokenPath) {
+		t.Errorf("tokenPath should be absolute, got %q", tokenPath)
+	}
+	if filepath.Base(credPath) != "credentials.json" {
+		t.Errorf("expected credentials.json, got %q", filepath.Base(credPath))
+	}
+	if filepath.Base(tokenPath) != "token.json" {
+		t.Errorf("expected token.json, got %q", filepath.Base(tokenPath))
+	}
+}
+
+// ----- generateStateToken -----
+
+func TestGenerateStateToken(t *testing.T) {
+	tok1, err := generateStateToken()
+	if err != nil {
+		t.Fatalf("generateStateToken() error: %v", err)
+	}
+	if len(tok1) == 0 {
+		t.Error("state token should not be empty")
+	}
+
+	tok2, err := generateStateToken()
+	if err != nil {
+		t.Fatalf("generateStateToken() second call error: %v", err)
+	}
+	if tok1 == tok2 {
+		t.Error("consecutive state tokens should differ (random)")
+	}
+}

--- a/internal/calendar/client_test.go
+++ b/internal/calendar/client_test.go
@@ -1,0 +1,376 @@
+// Copyright 2024 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package calendar
+
+import (
+	"testing"
+	"time"
+
+	"google.golang.org/api/calendar/v3"
+)
+
+// ----- isValidEmail -----
+
+func TestIsValidEmail(t *testing.T) {
+	cases := []struct {
+		input string
+		valid bool
+	}{
+		{"user@example.com", true},
+		{"user.name+tag@sub.domain.org", true},
+		{"a@b.io", true},
+		{"", false},
+		{"notanemail", false},
+		{"missing@", false},
+		{"@nodomain.com", false},
+		{"spaces in@email.com", false},
+	}
+	for _, tc := range cases {
+		got := isValidEmail(tc.input)
+		if got != tc.valid {
+			t.Errorf("isValidEmail(%q) = %v, want %v", tc.input, got, tc.valid)
+		}
+	}
+}
+
+// ----- stripRecurringInstanceSuffix -----
+
+func TestStripRecurringInstanceSuffix(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"abc123_20260310", "abc123"},
+		{"abc123_20260310T120000Z", "abc123"},
+		{"abc123", "abc123"},                           // no suffix
+		{"abc_def_20260310", "abc_def"},                // underscore in base ID
+		{"abc_20260310T000000Z", "abc"},                // datetime suffix
+	}
+	for _, tc := range cases {
+		got := stripRecurringInstanceSuffix(tc.input)
+		if got != tc.want {
+			t.Errorf("stripRecurringInstanceSuffix(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// ----- eventsOverlap -----
+
+func TestEventsOverlap(t *testing.T) {
+	base := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name   string
+		s1, e1 time.Time
+		s2, e2 time.Time
+		want   bool
+	}{
+		{
+			"overlapping events",
+			base, base.Add(2 * time.Hour),
+			base.Add(time.Hour), base.Add(3 * time.Hour),
+			true,
+		},
+		{
+			"contained event",
+			base, base.Add(4 * time.Hour),
+			base.Add(time.Hour), base.Add(2 * time.Hour),
+			true,
+		},
+		{
+			"sequential events (touching)",
+			base, base.Add(time.Hour),
+			base.Add(time.Hour), base.Add(2 * time.Hour),
+			false,
+		},
+		{
+			"non-overlapping events",
+			base, base.Add(time.Hour),
+			base.Add(2 * time.Hour), base.Add(3 * time.Hour),
+			false,
+		},
+		{
+			"same event times",
+			base, base.Add(time.Hour),
+			base, base.Add(time.Hour),
+			true,
+		},
+	}
+	for _, tc := range cases {
+		got := eventsOverlap(tc.s1, tc.e1, tc.s2, tc.e2)
+		if got != tc.want {
+			t.Errorf("%s: eventsOverlap = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// ----- calculateTimeRange -----
+
+func TestCalculateTimeRange_Today(t *testing.T) {
+	start, end := calculateTimeRange("today", time.Time{}, time.Time{}, "UTC")
+	now := time.Now().UTC()
+
+	if start.Day() != now.Day() {
+		t.Errorf("today start day = %d, want %d", start.Day(), now.Day())
+	}
+	if !end.After(start) {
+		t.Error("end should be after start")
+	}
+	if end.Sub(start) != 24*time.Hour {
+		t.Errorf("today range should be 24h, got %v", end.Sub(start))
+	}
+}
+
+func TestCalculateTimeRange_ThisWeek(t *testing.T) {
+	start, end := calculateTimeRange("this_week", time.Time{}, time.Time{}, "UTC")
+	if end.Sub(start) != 5*24*time.Hour {
+		t.Errorf("this_week range should be 5 days, got %v", end.Sub(start))
+	}
+	// start should be Monday
+	if start.Weekday() != time.Monday {
+		t.Errorf("this_week start should be Monday, got %v", start.Weekday())
+	}
+}
+
+func TestCalculateTimeRange_NextWeek(t *testing.T) {
+	start, end := calculateTimeRange("next_week", time.Time{}, time.Time{}, "UTC")
+	if end.Sub(start) != 5*24*time.Hour {
+		t.Errorf("next_week range should be 5 days, got %v", end.Sub(start))
+	}
+	if start.Weekday() != time.Monday {
+		t.Errorf("next_week start should be Monday, got %v", start.Weekday())
+	}
+	// next week's Monday should be after this week's Monday
+	thisStart, _ := calculateTimeRange("this_week", time.Time{}, time.Time{}, "UTC")
+	if !start.After(thisStart) {
+		t.Error("next_week start should be after this_week start")
+	}
+}
+
+func TestCalculateTimeRange_Custom(t *testing.T) {
+	min := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	max := time.Date(2026, 3, 31, 0, 0, 0, 0, time.UTC)
+
+	start, end := calculateTimeRange("custom", min, max, "UTC")
+	if !start.Equal(min) {
+		t.Errorf("custom start = %v, want %v", start, min)
+	}
+	if !end.Equal(max) {
+		t.Errorf("custom end = %v, want %v", end, max)
+	}
+}
+
+func TestCalculateTimeRange_CustomEmpty_FallsBackToToday(t *testing.T) {
+	// Custom with zero times falls back to today
+	start, end := calculateTimeRange("custom", time.Time{}, time.Time{}, "UTC")
+	if end.Sub(start) != 24*time.Hour {
+		t.Errorf("empty custom should fall back to 24h today range, got %v", end.Sub(start))
+	}
+}
+
+func TestCalculateTimeRange_InvalidTimezone(t *testing.T) {
+	// Should not panic with invalid timezone — falls back to UTC
+	start, end := calculateTimeRange("today", time.Time{}, time.Time{}, "Not/A/Zone")
+	if !end.After(start) {
+		t.Error("end should be after start even with invalid timezone")
+	}
+}
+
+// ----- parseEventTimes -----
+
+func TestParseEventTimes_TimedEvent(t *testing.T) {
+	event := &calendar.Event{
+		Start: &calendar.EventDateTime{DateTime: "2026-03-10T09:00:00Z"},
+		End:   &calendar.EventDateTime{DateTime: "2026-03-10T10:00:00Z"},
+	}
+	start, end, allDay, err := parseEventTimes(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allDay {
+		t.Error("expected timed event, not all-day")
+	}
+	if end.Sub(start) != time.Hour {
+		t.Errorf("expected 1h duration, got %v", end.Sub(start))
+	}
+}
+
+func TestParseEventTimes_AllDayEvent(t *testing.T) {
+	event := &calendar.Event{
+		Start: &calendar.EventDateTime{Date: "2026-03-10"},
+		End:   &calendar.EventDateTime{Date: "2026-03-11"},
+	}
+	_, _, allDay, err := parseEventTimes(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allDay {
+		t.Error("expected all-day event")
+	}
+}
+
+func TestParseEventTimes_MissingTimes(t *testing.T) {
+	event := &calendar.Event{}
+	_, _, _, err := parseEventTimes(event)
+	if err == nil {
+		t.Error("expected error for event with missing start/end")
+	}
+}
+
+func TestParseEventTimes_InvalidDateTime(t *testing.T) {
+	event := &calendar.Event{
+		Start: &calendar.EventDateTime{DateTime: "not-a-date"},
+		End:   &calendar.EventDateTime{DateTime: "also-not-a-date"},
+	}
+	_, _, _, err := parseEventTimes(event)
+	if err == nil {
+		t.Error("expected error for invalid datetime string")
+	}
+}
+
+// ----- NewClient and SearchAttendees (no service call needed) -----
+
+func TestNewClient(t *testing.T) {
+	c := NewClient(nil, nil)
+	if c == nil {
+		t.Fatal("NewClient should return a non-nil client")
+	}
+}
+
+func TestSearchAttendees_ValidEmail(t *testing.T) {
+	c := &Client{}
+	results, err := c.SearchAttendees(AttendeeSearchParams{Query: "user@example.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 || results[0] != "user@example.com" {
+		t.Errorf("expected [user@example.com], got %v", results)
+	}
+}
+
+func TestSearchAttendees_InvalidEmail(t *testing.T) {
+	c := &Client{}
+	_, err := c.SearchAttendees(AttendeeSearchParams{Query: "notanemail"})
+	if err == nil {
+		t.Error("expected error for non-email query")
+	}
+}
+
+// ----- DetectOverlaps -----
+
+func TestDetectOverlaps_NoOverlap(t *testing.T) {
+	c := &Client{}
+	now := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	events := []*calendar.Event{
+		{
+			Id:    "e1",
+			Start: &calendar.EventDateTime{DateTime: now.Format(time.RFC3339)},
+			End:   &calendar.EventDateTime{DateTime: now.Add(time.Hour).Format(time.RFC3339)},
+		},
+		{
+			Id:    "e2",
+			Start: &calendar.EventDateTime{DateTime: now.Add(2 * time.Hour).Format(time.RFC3339)},
+			End:   &calendar.EventDateTime{DateTime: now.Add(3 * time.Hour).Format(time.RFC3339)},
+		},
+	}
+	overlaps := c.DetectOverlaps(events, false)
+	if overlaps["e1"] {
+		t.Error("e1 should not be marked as overlapping")
+	}
+	if overlaps["e2"] {
+		t.Error("e2 should not be marked as overlapping")
+	}
+}
+
+func TestDetectOverlaps_WithOverlap(t *testing.T) {
+	c := &Client{}
+	now := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	events := []*calendar.Event{
+		{
+			Id:    "e1",
+			Start: &calendar.EventDateTime{DateTime: now.Format(time.RFC3339)},
+			End:   &calendar.EventDateTime{DateTime: now.Add(2 * time.Hour).Format(time.RFC3339)},
+		},
+		{
+			Id:    "e2",
+			Start: &calendar.EventDateTime{DateTime: now.Add(time.Hour).Format(time.RFC3339)},
+			End:   &calendar.EventDateTime{DateTime: now.Add(3 * time.Hour).Format(time.RFC3339)},
+		},
+	}
+	overlaps := c.DetectOverlaps(events, false)
+	if !overlaps["e1"] {
+		t.Error("e1 should be marked as overlapping")
+	}
+	if !overlaps["e2"] {
+		t.Error("e2 should be marked as overlapping")
+	}
+}
+
+func TestDetectOverlaps_AllDayEventsSkipped(t *testing.T) {
+	c := &Client{}
+	// All-day events should be skipped in overlap detection
+	events := []*calendar.Event{
+		{
+			Id:    "allday1",
+			Start: &calendar.EventDateTime{Date: "2026-01-01"},
+			End:   &calendar.EventDateTime{Date: "2026-01-02"},
+		},
+		{
+			Id:    "allday2",
+			Start: &calendar.EventDateTime{Date: "2026-01-01"},
+			End:   &calendar.EventDateTime{Date: "2026-01-02"},
+		},
+	}
+	overlaps := c.DetectOverlaps(events, false)
+	if overlaps["allday1"] {
+		t.Error("all-day events should not be marked as overlapping")
+	}
+}
+
+func TestDetectOverlaps_Empty(t *testing.T) {
+	c := &Client{}
+	overlaps := c.DetectOverlaps(nil, false)
+	if len(overlaps) != 0 {
+		t.Errorf("expected empty overlaps map, got %d entries", len(overlaps))
+	}
+}
+
+// isEventDeclined is only testable when attendees is nil (no API call needed)
+func TestIsEventDeclined_NoAttendees(t *testing.T) {
+	c := &Client{}
+	event := &calendar.Event{Attendees: nil}
+	if c.isEventDeclined(event) {
+		t.Error("event with no attendees should not be declined")
+	}
+}
+
+// ----- parseFileID -----
+
+func TestParseFileID(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"https://docs.google.com/document/d/abc123XYZ/edit", "abc123XYZ"},
+		{"https://drive.google.com/file/d/xyz789/view", "xyz789"},
+		{"rawfileid", "rawfileid"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := parseFileID(tc.input)
+		if got != tc.want {
+			t.Errorf("parseFileID(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,322 @@
+// Copyright 2024 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+)
+
+// mockHandler is a test double for ToolHandler that records calls and returns preset results.
+type mockHandler struct {
+	result *CallToolResult
+	err    error
+	called string
+}
+
+func (m *mockHandler) HandleTool(name string, _ map[string]interface{}) (*CallToolResult, error) {
+	m.called = name
+	return m.result, m.err
+}
+
+func newTestServer(h ToolHandler) *Server {
+	s := NewServer(h)
+	s.RegisterTool(Tool{
+		Name:        "test_tool",
+		Description: "A test tool",
+		InputSchema: ToolSchema{Type: "object", Properties: map[string]interface{}{}},
+	})
+	return s
+}
+
+
+func TestHandleInitialize(t *testing.T) {
+	s := newTestServer(&mockHandler{})
+	req := &Request{JSONRPC: "2.0", ID: 1, Method: "initialize"}
+	resp := s.handleRequest(req)
+
+	if resp.Error != nil {
+		t.Fatalf("expected no error, got %v", resp.Error)
+	}
+	result, ok := resp.Result.(InitializeResult)
+	if !ok {
+		t.Fatalf("expected InitializeResult, got %T", resp.Result)
+	}
+	if result.ProtocolVersion == "" {
+		t.Error("protocol version should not be empty")
+	}
+	if result.ServerInfo.Name != "gcal-mcp-server" {
+		t.Errorf("expected server name 'gcal-mcp-server', got %q", result.ServerInfo.Name)
+	}
+	if result.Capabilities.Tools == nil {
+		t.Error("expected tools capability to be present")
+	}
+}
+
+func TestHandleInitialized(t *testing.T) {
+	s := newTestServer(&mockHandler{})
+	req := &Request{JSONRPC: "2.0", ID: 2, Method: "initialized"}
+	resp := s.handleRequest(req)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+}
+
+func TestHandleListTools(t *testing.T) {
+	s := newTestServer(&mockHandler{})
+	req := &Request{JSONRPC: "2.0", ID: 3, Method: "tools/list"}
+	resp := s.handleRequest(req)
+
+	if resp.Error != nil {
+		t.Fatalf("expected no error, got %v", resp.Error)
+	}
+	result, ok := resp.Result.(ListToolsResult)
+	if !ok {
+		t.Fatalf("expected ListToolsResult, got %T", resp.Result)
+	}
+	if len(result.Tools) != 1 {
+		t.Errorf("expected 1 tool, got %d", len(result.Tools))
+	}
+	if result.Tools[0].Name != "test_tool" {
+		t.Errorf("expected tool name 'test_tool', got %q", result.Tools[0].Name)
+	}
+}
+
+func TestHandleCallTool_KnownTool(t *testing.T) {
+	handler := &mockHandler{
+		result: &CallToolResult{
+			Content: []ToolResult{{Type: "text", Text: "hello"}},
+		},
+	}
+	s := newTestServer(handler)
+
+	params, _ := json.Marshal(CallToolParams{Name: "test_tool", Arguments: map[string]interface{}{"key": "value"}})
+	req := &Request{JSONRPC: "2.0", ID: 4, Method: "tools/call", Params: params}
+	resp := s.handleRequest(req)
+
+	if resp.Error != nil {
+		t.Fatalf("expected no error, got %v", resp.Error)
+	}
+	if handler.called != "test_tool" {
+		t.Errorf("expected handler called with 'test_tool', got %q", handler.called)
+	}
+}
+
+func TestHandleCallTool_UnknownTool(t *testing.T) {
+	s := newTestServer(&mockHandler{})
+
+	params, _ := json.Marshal(CallToolParams{Name: "no_such_tool"})
+	req := &Request{JSONRPC: "2.0", ID: 5, Method: "tools/call", Params: params}
+	resp := s.handleRequest(req)
+
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown tool, got nil")
+	}
+	if resp.Error.Code != -32602 {
+		t.Errorf("expected error code -32602, got %d", resp.Error.Code)
+	}
+}
+
+func TestHandleCallTool_HandlerError(t *testing.T) {
+	handler := &mockHandler{err: fmt.Errorf("tool failed")}
+	s := newTestServer(handler)
+
+	params, _ := json.Marshal(CallToolParams{Name: "test_tool"})
+	req := &Request{JSONRPC: "2.0", ID: 6, Method: "tools/call", Params: params}
+	resp := s.handleRequest(req)
+
+	// Handler errors are returned as a CallToolResult with IsError=true, not as a JSON-RPC error.
+	if resp.Error != nil {
+		t.Fatalf("expected no JSON-RPC error, got %v", resp.Error)
+	}
+	result, ok := resp.Result.(*CallToolResult)
+	if !ok {
+		t.Fatalf("expected *CallToolResult, got %T", resp.Result)
+	}
+	if result.IsError == nil || !*result.IsError {
+		t.Error("expected IsError to be true")
+	}
+}
+
+func TestHandleUnknownMethod(t *testing.T) {
+	s := newTestServer(&mockHandler{})
+	req := &Request{JSONRPC: "2.0", ID: 7, Method: "not/a/method"}
+	resp := s.handleRequest(req)
+
+	if resp.Error == nil {
+		t.Fatal("expected error for unknown method")
+	}
+	if resp.Error.Code != -32601 {
+		t.Errorf("expected -32601 (method not found), got %d", resp.Error.Code)
+	}
+}
+
+func TestHandleShutdown(t *testing.T) {
+	s := newTestServer(&mockHandler{})
+	req := &Request{JSONRPC: "2.0", ID: 8, Method: "shutdown"}
+	resp := s.handleRequest(req)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error on shutdown: %v", resp.Error)
+	}
+}
+
+// ----- sendResponse / sendError / LogToStderr -----
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = old
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	return string(buf[:n])
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stderr = w
+
+	fn()
+
+	w.Close()
+	os.Stderr = old
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	return string(buf[:n])
+}
+
+func TestSendResponse(t *testing.T) {
+	s := newTestServer(&mockHandler{})
+	resp := &Response{JSONRPC: "2.0", ID: 1, Result: map[string]string{"ok": "true"}}
+
+	out := captureStdout(t, func() {
+		if err := s.sendResponse(resp); err != nil {
+			t.Errorf("sendResponse error: %v", err)
+		}
+	})
+	if len(out) == 0 {
+		t.Error("sendResponse should write to stdout")
+	}
+	var got Response
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Errorf("sendResponse output should be valid JSON: %v", err)
+	}
+}
+
+func TestSendError(t *testing.T) {
+	s := newTestServer(&mockHandler{})
+	out := captureStdout(t, func() {
+		s.sendError(42, -32600, "invalid request", nil)
+	})
+	if len(out) == 0 {
+		t.Error("sendError should write to stdout")
+	}
+	var got Response
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Errorf("sendError output should be valid JSON: %v", err)
+	}
+	if got.Error == nil || got.Error.Code != -32600 {
+		t.Errorf("expected error code -32600, got %v", got.Error)
+	}
+}
+
+func TestLogToStderr(t *testing.T) {
+	s := newTestServer(&mockHandler{})
+	out := captureStderr(t, func() {
+		s.LogToStderr("test message %s", "hello")
+	})
+	if out == "" {
+		t.Error("LogToStderr should write to stderr")
+	}
+	if !contains(out, "test message hello") {
+		t.Errorf("expected 'test message hello' in stderr, got %q", out)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsAt(s, sub))
+}
+
+func containsAt(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func TestHandleCallTool_InvalidParams(t *testing.T) {
+	s := newTestServer(&mockHandler{})
+	// Params that can't unmarshal into CallToolParams
+	req := &Request{JSONRPC: "2.0", ID: 9, Method: "tools/call", Params: json.RawMessage(`not json`)}
+	resp := s.handleRequest(req)
+	if resp.Error == nil {
+		t.Fatal("expected error for invalid params")
+	}
+}
+
+func TestHandleInitialize_InvalidParams(t *testing.T) {
+	s := newTestServer(&mockHandler{})
+	req := &Request{JSONRPC: "2.0", ID: 10, Method: "initialize", Params: json.RawMessage(`not json`)}
+	resp := s.handleRequest(req)
+	if resp.Error == nil {
+		t.Fatal("expected error for invalid initialize params")
+	}
+}
+
+func TestNewServer_EmptyTools(t *testing.T) {
+	s := NewServer(&mockHandler{})
+	if len(s.tools) != 0 {
+		t.Errorf("new server should have 0 tools, got %d", len(s.tools))
+	}
+}
+
+func TestRegisterTool(t *testing.T) {
+	s := NewServer(&mockHandler{})
+	tool := Tool{Name: "my_tool", Description: "desc"}
+	s.RegisterTool(tool)
+	if _, ok := s.tools["my_tool"]; !ok {
+		t.Error("tool should be registered after RegisterTool")
+	}
+}
+
+func TestBoolPtr(t *testing.T) {
+	p := boolPtr(true)
+	if p == nil || !*p {
+		t.Error("boolPtr(true) should return pointer to true")
+	}
+	p = boolPtr(false)
+	if p == nil || *p {
+		t.Error("boolPtr(false) should return pointer to false")
+	}
+}

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,14 @@
+# Ruff configuration for gcal-mcp-server Python code
+target-version = "py312"
+
+[lint]
+select = [
+    "E",   # pycodestyle errors
+    "F",   # pyflakes
+    "W",   # pycodestyle warnings
+    "I",   # isort
+    "UP",  # pyupgrade
+]
+ignore = [
+    "E501",  # line too long — TUI code has intentionally long format strings
+]


### PR DESCRIPTION
## Summary

- 48 new Python tests in `calender/test_tui_ui.py` for the curses-based `CalendarTUI`
- No live credentials, terminal, or display required — curses stdscr and MCP client are fully mocked
- Covers CalendarEvent data model, TUI initialisation, event filtering (all 3 display modes), keyboard navigation, edge cases (empty events, no terminal), and draw method smoke tests

Because the TUI uses raw `curses` (not Textual), the Textual `App.run_test()` harness is not applicable. Instead tests mock `curses.stdscr` and drive the business logic directly, which is the correct approach for this type of TUI.

Jira: [ACM-34711](https://redhat.atlassian.net/browse/ACM-34711)

## Test plan

- [x] `pytest calender/test_tui_ui.py` — 48 tests pass
- [x] `make test-python` picks up the new file automatically
- [x] `make lint-python` passes with no violations