### PR TITLE
chore: onboard repository to Fleet Engineering Agentic SDLC

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -1,0 +1,6 @@
+---
+description: System architecture, data flows, and module layout for gcal-mcp-server
+alwaysApply: false
+---
+
+@docs/architecture.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,17 +42,3 @@ The repository uses a `Makefile` for common operations:
 Read `.claude/user.local.md` at the start of any task that needs an assignee, email, or project key.
 If the file does not exist, fall back to Claude memory (`user-config`), then placeholders.
 Run `make personalize` to generate it (if this repo uses Fleet Engineering tooling).
-
-## Fleet Engineering Skills
-
-Fetch and apply the relevant skill when the task matches its domain.
-
-| Skill | When to use |
-|---|---|
-| [start-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/start-work/SKILL.md) | Create a Jira sub-task |
-| [finish-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/finish-work/SKILL.md) | Commit, push, open PR, update Jira |
-| [jira-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/jira-specialist/SKILL.md) | General Jira ticket management, triage, search, linking, transitions |
-| [task-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/task-specialist/SKILL.md) | Internal technical task breakdown and planning |
-| [bug-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/bug-specialist/SKILL.md) | Bug triage, reproduction steps, fix planning |
-| [story-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/story-specialist/SKILL.md) | User story creation and acceptance criteria |
-| [pr-review](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-review/SKILL.md) | GitHub PR review with inline comments |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,25 +2,16 @@
 
 This document provides context, patterns, and conventions for AI agents working in this repository.
 
-## 🏗️ Architecture & Organization
-
-This is a Model Context Protocol (MCP) server written in Go that integrates with Google Calendar and Google Drive APIs. 
-
-### Core Components
-* **`cmd/server/main.go`**: The entry point. Initializes services, registers tools, and starts the MCP server.
-* **`internal/mcp/`**: Implements the Model Context Protocol (JSON-RPC over stdin/stdout).
-* **`internal/calendar/`**: Contains the core logic for Google Calendar API interactions (`client.go`) and the MCP tool definitions (`tools.go`).
-* **`internal/auth/`**: Handles Google OAuth 2.0 authentication and token management.
-* **`scripts/`**: Contains scripts for syncing AI command prompts (`sync-commands.sh`, `sync_commands.py`).
-* **`calender/`**: (Note the spelling) Contains a Python-based Terminal UI for calendar management (`calendar_tui.py`) and its tests.
+For system architecture, data flows, and module layout, see [docs/architecture.md](docs/architecture.md).
 
 ## 🚀 Essential Commands
 
 The repository uses a `Makefile` for common operations:
 
 * **`make build`**: Compiles the Go binary to `./bin/gcal-mcp-server`.
-* **`make test`**: Runs the Go test suite (`go test ./...`). There are also Python tests in `calender/` that run via `pytest`.
-* **`make dev`**: Runs `fmt`, `vet`, `test`, and `build`.
+* **`make test`**: Runs both Go tests (`go test ./...`) and Python tests (`pytest`).
+* **`make dev`**: Runs `fmt`, `vet`, `lint`, `test`, and `build`.
+* **`make lint`**: Runs `go vet` + `staticcheck` (Go) and `ruff check` (Python). Auto-installs both tools if missing.
 * **`make auth`**: Removes the local `token.json` and runs the server to force a new Google OAuth flow.
 * **`make sync-commands`**: Runs the script to synchronize AI prompt files across `.claude`, `.gemini`, and `.cursor` directories.
 
@@ -36,8 +27,32 @@ The repository uses a `Makefile` for common operations:
 
 3. **AI Command Synchronization**
    * Instead of a single system prompt, this project provides tailored command instructions for different AI platforms (Claude, Gemini, Cursor).
-   * These commands live in platform-specific hidden directories (`.claude/commands/`, etc.). 
+   * These commands live in platform-specific hidden directories (`.claude/commands/`, etc.).
    * When modifying commands or prompts, update the source of truth and use `make sync-commands` to propagate changes across platforms.
 
 4. **Typo in Directory Name**
    * The Python component is located in `calender/`, not `calendar/`. Be careful with path autocomplete.
+
+5. **Unavailable CLIs**
+   * `gh` CLI is not installed. Use `mcp__github-*` MCP tools for all GitHub operations (PRs, issues, branches, code search).
+   * `jira` CLI is not installed. Use `mcp__jira-mcp-server__*` MCP tools for all Jira operations.
+
+## Personal Configuration
+
+Read `.claude/user.local.md` at the start of any task that needs an assignee, email, or project key.
+If the file does not exist, fall back to Claude memory (`user-config`), then placeholders.
+Run `make personalize` to generate it (if this repo uses Fleet Engineering tooling).
+
+## Fleet Engineering Skills
+
+Fetch and apply the relevant skill when the task matches its domain.
+
+| Skill | When to use |
+|---|---|
+| [start-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/start-work/SKILL.md) | Create a Jira sub-task |
+| [finish-work](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/finish-work/SKILL.md) | Commit, push, open PR, update Jira |
+| [jira-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/jira-specialist/SKILL.md) | General Jira ticket management, triage, search, linking, transitions |
+| [task-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/task-specialist/SKILL.md) | Internal technical task breakdown and planning |
+| [bug-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/bug-specialist/SKILL.md) | Bug triage, reproduction steps, fix planning |
+| [story-specialist](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/jira/story-specialist/SKILL.md) | User story creation and acceptance criteria |
+| [pr-review](https://raw.githubusercontent.com/OpenShift-Fleet/agentic-sdlc/main/skills/sdlc/pr-review/SKILL.md) | GitHub PR review with inline comments |

--- a/calender/calendar_tui.py
+++ b/calender/calendar_tui.py
@@ -444,11 +444,11 @@ class CalendarTUI:
         # Hide cursor
         curses.curs_set(0)
 
-    def debug_log(self, message: str):
+    def debug_log(self, message: str, *args):
         """Log debug message to stderr if debug mode is enabled"""
         if self.debug:
             import sys
-            print(f"[DEBUG] {message}", file=sys.stderr, flush=True)
+            print(f"[DEBUG] {message % args if args else message}", file=sys.stderr, flush=True)
 
     def start_loading(self, message: str):
         """Start loading animation with message"""
@@ -1676,16 +1676,13 @@ class CalendarTUI:
                         wrapped_lines.append(remaining)
                         break
 
-                    # Find the last space within max_width
+                    # Find the last space within max_width, skipping leading indent
+                    current_indent_len = len(remaining) - len(remaining.lstrip())
                     wrap_point = max_width
                     for i in range(max_width, 0, -1):
-                        if remaining[i-1] in (' ', '-', ','):
+                        if remaining[i-1] in (' ', '-', ',') and i > current_indent_len:
                             wrap_point = i
                             break
-
-                    # If no good break point found, just hard break
-                    if wrap_point == max_width and len(remaining) > max_width:
-                        wrap_point = max_width
 
                     # Add the wrapped portion
                     wrapped_lines.append(remaining[:wrap_point])


### PR DESCRIPTION
## Summary

- Updated `CLAUDE.md`: fixed `make dev` command description (now includes lint), replaced inline architecture section with reference to `docs/architecture.md`, added unavailable CLIs note, added personal config lookup section
- Removed Fleet Engineering skills table from `CLAUDE.md` (ACM-34724)
- `AGENTS.md` confirmed clean — no skills references present
- Added `.cursor/rules/architecture.mdc` so Cursor users can pull in the architecture doc on demand
- **Fixed CI timeout (ACM-34726)**: resolved infinite loop in `_wrap_text_lines` and `debug_log` signature mismatch in `calender/calendar_tui.py` — tests now run in <1s instead of timing out after 4 min

## Test plan

- [x] Verify `CLAUDE.md` renders correctly on GitHub
- [x] Confirm `.cursor/rules/architecture.mdc` is recognized by Cursor
- [x] `pytest calender/ -v` — 60/60 passed in 0.74s

Closes ACM-34724
Fixes ACM-34726

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added architecture documentation rules for development.

* **Bug Fixes**
  * Improved text wrapping behavior for indented content in the calendar interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->