### PR TITLE
fix(tests): replace asyncio.get_event_loop() with asyncio.run() in two tests

### DIFF
--- a/calender/test_tui_ui.py
+++ b/calender/test_tui_ui.py
@@ -433,7 +433,7 @@ class TestEdgeCases:
         async def run():
             await tui.delete_event()
 
-        asyncio.get_event_loop().run_until_complete(run())
+        asyncio.run(run())
         assert "No event" in tui.status_message or tui.status_message != ""
 
     def test_recommendations_invalid_when_no_time_range(self):
@@ -503,4 +503,4 @@ class TestMCPClient:
         async def run():
             await client.disconnect()
 
-        asyncio.get_event_loop().run_until_complete(run())
+        asyncio.run(run())


### PR DESCRIPTION
## Summary

Fixes two failing CI tests in `calender/test_tui_ui.py` caused by `asyncio.get_event_loop()` raising `RuntimeError` on Python 3.10+.

- `test_delete_event_no_events_sets_status` (line 436)
- `test_disconnect_without_connect_does_not_crash` (line 506)

Both tests called `asyncio.get_event_loop().run_until_complete()` directly. In Python 3.10+, `asyncio.get_event_loop()` raises `RuntimeError: There is no current event loop in thread 'MainThread'` when no loop has been created yet. Replaced with `asyncio.run()`, which is the recommended approach since Python 3.7.

Fixes [ACM-34764](https://redhat.atlassian.net/browse/ACM-34764)

## Test plan

- [x] `pytest calender/` — 60/60 tests pass
- [x] `go vet ./...` — passes
- [x] `ruff check calender/` — passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

No user-facing changes in this release. This update includes internal testing infrastructure improvements to enhance test execution reliability.

* **Tests**
  * Updated test execution methods for improved async handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->