### PR TITLE
fix(deps): resolve security vulnerabilities in Go dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module gcal-mcp-server
 
 go 1.26.3
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	golang.org/x/oauth2 v0.36.0


### PR DESCRIPTION
## Security audit summary

### CVEs resolved
| ID | Module | Severity | Fixed in |
|----|--------|----------|----------|
| GO-2026-5856 | Go toolchain (crypto/tls) | Medium | go1.26.5 |
| GO-2026-4970 | Go toolchain (os) | Medium | go1.26.5 |

### CVEs with no fix available
| ID | Module | Notes |
|----|--------|-------|
| GO-2026-5932 | golang.org/x/crypto (openpgp package) | Package is permanently unmaintained/unsafe by design; no fixed version exists. Confirmed via `go mod why golang.org/x/crypto` and `go list -deps ./...` that the `openpgp` package is **not imported or called** anywhere in this codebase (it's a transitive dependency pulled in by another module, unused by our build). No code change or TODO needed since there is no import site in this repo. |

### Modules changed
- No third-party Go module versions were changed.
- `go.mod`: `toolchain` directive bumped from `go1.26.4` -> `go1.26.5` to pick up the stdlib `crypto/tls` and `os` fixes.

### Verification
- [x] govulncheck: clean (0 vulnerabilities affecting code; 1 module-level advisory with no fix, not imported/called)
- [x] go build ./...: passing
- [x] golangci-lint run ./...: passing (0 issues)
- [x] go test ./...: passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain to version 1.26.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->