### PR TITLE
fix(deps): resolve security vulnerabilities in Go dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module gcal-mcp-server
 
 go 1.26.3
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	golang.org/x/oauth2 v0.36.0


### PR DESCRIPTION
## Security audit summary

### CVEs resolved
| ID | Module | Severity | Fixed in |
|----|--------|----------|----------|
| GO-2026-5856 | Go toolchain (crypto/tls) | Medium | go1.26.5 |
| GO-2026-4970 | Go toolchain (os) | Medium | go1.26.5 |

### CVEs found but not fixed (no fix available)
| ID | Module | Severity | Notes |
|----|--------|----------|-------|
| GO-2026-5932 | golang.org/x/crypto/openpgp | N/A | Unmaintained/unsafe package. Fixed in: N/A. Confirmed via `go list -deps ./...` that this package is **not imported anywhere** in this codebase (it is only present transitively in the `golang.org/x/crypto` module, which is required for the unrelated `cryptobyte` package via `s2a-go`). No import site exists to add an inline TODO comment. Not actionable at this time. |

### Modules changed
- Go toolchain directive bumped: `go1.26.4` → `go1.26.5` (in `go.mod`)
- No third-party Go module versions were changed (no CVE required a `go get` bump).

### Verification
- [x] govulncheck: 0 vulnerabilities affecting code (1 unfixable module-level finding not in import graph, documented above)
- [x] go build ./...: passing
- [x] go vet ./...: passing
- [x] staticcheck ./...: passing
- [x] golangci-lint run ./...: passing (0 issues)
- [x] go test ./... (with -cover): passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s Go toolchain version to 1.26.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->