### PR TITLE
fix(deps): resolve security vulnerabilities in Python dependencies

### DIFF
--- a/calender/requirements.txt
+++ b/calender/requirements.txt
@@ -1,3 +1,3 @@
-mcp==1.27.2  # TODO(CVE-2025-45768): pyjwt transitive dep has disputed "weak encryption" advisory (PYSEC-2025-183); no fixed version exists upstream; supplier contests the finding
+mcp==1.28.1  # CVE-2026-59950 (GHSA-vj7q-gjh5-988w): fixed - deprecated websocket_server transport lacked Host/Origin validation; not used by this project but patched anyway. TODO(CVE-2025-45768): pyjwt transitive dep has disputed "weak encryption" advisory (PYSEC-2025-183); no fixed version exists upstream; supplier contests the finding
 python-multipart>=0.0.30
 starlette>=1.2.1  # PYSEC-2026-161: starlette<1.0.1 allows Host header injection leading to auth bypass; mcp pulls starlette as a transitive dep


### PR DESCRIPTION
## Security audit summary

### CVEs resolved
| CVE ID | Package | Severity | Fixed in |
|--------|---------|----------|----------|
| CVE-2026-59950 (GHSA-vj7q-gjh5-988w) | mcp | Moderate | 1.28.1 |

**Details:** The deprecated `mcp.server.websocket.websocket_server` transport accepted WebSocket handshakes without validating `Host`/`Origin` headers, allowing a malicious web page to open a cross-origin WebSocket session to a locally/LAN-bound MCP server and invoke its tools. This project does not use the WebSocket transport (only stdio), so it was not directly exploitable here, but the upstream fix was applied out of caution.

### Packages changed
| Package | Old | New |
|---------|-----|-----|
| mcp | 1.27.2 | 1.28.1 |

Pre-existing documented/disputed findings were left untouched (no change in status):
- `CVE-2025-45768` / PYSEC-2025-183 (pyjwt transitive dep, disputed, no fix available)
- `PYSEC-2026-161` (starlette Host header injection — already resolved by existing `starlette>=1.2.1` pin)

### Verification
- [x] pip-audit: clean (0 known vulnerabilities)
- [x] Lint (`ruff check calender/`): passing
- [x] Tests (`pytest` in `calender/`): 60 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MCP dependency to version 1.28.1.
  * Included an updated security advisory reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->