### PR TITLE
fix(deps): resolve security vulnerabilities in Go dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,6 @@ require (
 	google.golang.org/genproto v0.0.0-20260519071638-aa98bba5eb94 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260519071638-aa98bba5eb94 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260608224507-4308a22a1bab // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260519071638-aa98bba5eb94 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260519071638-aa98bba5eb94/go.mod h1:1dCETSCY2YKZNXQE3h4fun3TYwF5p8jejRKZgfWAgAY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260608224507-4308a22a1bab h1:cY0oV1VnAqvaim8VsR8ZyEKAudzbRJMRGwD3W/L7yOw=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260608224507-4308a22a1bab/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Security audit summary

### CVEs resolved
| ID | Module | Severity | Fixed in |
|----|--------|----------|----------|
| GO-2026-6061 | google.golang.org/grpc | High (xDS RBAC authz engine + HTTP/2 transport server vulnerabilities) | v1.82.1 |

### CVEs noted (no fix available)
| ID | Module | Notes |
|----|--------|-------|
| GO-2026-5932 | golang.org/x/crypto (openpgp package) | No fixed version exists upstream (package is unmaintained/unsafe by design). This is an indirect, transitive dependency — govulncheck reports it only as a module-level finding, not a symbol-level finding, meaning this repository's code does not import or call the vulnerable package. No code changes possible/required. |

### Modules changed
- `google.golang.org/grpc`: v1.81.1 → v1.82.1 (direct requirement; go.sum updated accordingly)

Only the module required to fix GO-2026-6061 was updated — no opportunistic upgrades.

### Verification
- [x] govulncheck: clean (0 symbol-level vulnerabilities; 1 module-level finding with no available fix, not called by code)
- [x] go build ./...: passing
- [x] golangci-lint run ./...: passing (0 issues)
- [x] go test ./...: passing (internal/auth, internal/calendar, internal/mcp)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying networking dependency to improve compatibility and maintenance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->