### PR TITLE
build(deps): update Python dependencies to latest stable versions

### DIFF
--- a/calender/requirements.txt
+++ b/calender/requirements.txt
@@ -1,3 +1,3 @@
-mcp==1.28.1  # CVE-2026-59950 (GHSA-vj7q-gjh5-988w): fixed - deprecated websocket_server transport lacked Host/Origin validation; not used by this project but patched anyway. TODO(CVE-2025-45768): pyjwt transitive dep has disputed "weak encryption" advisory (PYSEC-2025-183); no fixed version exists upstream; supplier contests the finding
+mcp==2.0.0  # CVE-2026-59950 (GHSA-vj7q-gjh5-988w): fixed - deprecated websocket_server transport lacked Host/Origin validation; not used by this project but patched anyway. TODO(CVE-2025-45768): pyjwt transitive dep has disputed "weak encryption" advisory (PYSEC-2025-183); no fixed version exists upstream; supplier contests the finding
 python-multipart>=0.0.30
 starlette>=1.2.1  # PYSEC-2026-161: starlette<1.0.1 allows Host header injection leading to auth bypass; mcp pulls starlette as a transitive dep


### PR DESCRIPTION
## Dependency update summary

### Packages updated
| Package | Old version | New version | Tool |
|---------|-------------|-------------|------|
| mcp | 1.28.1 | 2.0.0 | pip |

`python-multipart` (>=0.0.30) and `starlette` (>=1.2.1) already resolve to their latest stable releases (0.0.32 and 1.3.1 respectively) under the existing constraints, so no pin changes were needed for those two.

### Verification
- [x] Pre-update CVE scan: clean
- [x] Lint: passing
- [x] Tests: passing (60 passed)
- [x] Post-update CVE scan: clean
