### PR TITLE
fix(deps): resolve security vulnerabilities in Go dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,6 @@ require (
 	google.golang.org/genproto v0.0.0-20260519071638-aa98bba5eb94 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260519071638-aa98bba5eb94 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260608224507-4308a22a1bab // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260519071638-aa98bba5eb94 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260519071638-aa98bba5eb94/go.mod h1:1dCETSCY2YKZNXQE3h4fun3TYwF5p8jejRKZgfWAgAY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260608224507-4308a22a1bab h1:cY0oV1VnAqvaim8VsR8ZyEKAudzbRJMRGwD3W/L7yOw=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260608224507-4308a22a1bab/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Security audit summary

### CVEs resolved
| ID | Module | Severity | Fixed in |
|----|--------|----------|----------|
| GO-2026-6061 | google.golang.org/grpc | High | v1.82.1 |

Vulnerability in the xDS RBAC authorization engine and the HTTP/2 transport
server implementation in `google.golang.org/grpc`. Confirmed reachable from
this codebase via `internal/mcp/server.go` (LogToStderr) and
`internal/calendar/client.go` (calculateTimeRange).

### Not fixed (no patch available)
| ID | Module | Notes |
|----|--------|-------|
| GO-2026-5932 | golang.org/x/crypto (openpgp) | Package is unmaintained/unsafe by design; no fixed version exists. Present only as a transitive dependency — not imported or called anywhere in this codebase, so no inline `// TODO` was added (no import site exists to annotate). |

### Modules changed
- `google.golang.org/grpc`: v1.81.1 → v1.82.1 (direct fix for GO-2026-6061; go.sum updated accordingly for its transitive deps)

### Verification
- [x] govulncheck: clean (0 vulnerabilities affecting code; 1 unreachable/unfixable transitive finding documented above)
- [x] go build ./...: passing
- [x] golangci-lint run ./...: passing (0 issues)
- [x] go test ./...: passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying networking dependency to its latest compatible patch version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->