### PR TITLE
ci: add auto-merge workflow for trusted dependency-update PRs

### DIFF
--- a/.github/workflows/auto-merge-deps.yaml
+++ b/.github/workflows/auto-merge-deps.yaml
@@ -13,6 +13,9 @@ on:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -20,17 +23,20 @@ jobs:
       - name: Get eligible dependency PRs
         id: get_prs
         run: |
-          # Only PRs authored by the trusted jnpacker PAT identity, on a
-          # dependency-update branch (created by the swarm-deps-agent bot),
-          # are eligible for auto-merge. Also require the PR to be mergeable
-          # and all non-tide checks to have passed.
-          prs=$(gh pr list --state open --json number,title,url,author,headRefName,statusCheckRollup,mergeable --jq '
+          # Only PRs authored by the trusted jnpacker PAT identity, targeting
+          # main, on a dependency-update branch (created by the
+          # swarm-deps-agent bot), are eligible for auto-merge. Also require
+          # the PR to be mergeable and every non-tide check to have
+          # completed successfully (not just "at least one success" - a
+          # pending check must not count as passing).
+          prs=$(gh pr list --state open --base main --json number,title,url,author,headRefName,headRefOid,statusCheckRollup,mergeable --jq '
             .[] | select(
               (.author.login == "jnpacker") and
               (.headRefName | test("^(fix|build)/(go|python)-deps-")) and
               (.mergeable == "MERGEABLE") and
-              ([.statusCheckRollup[] | select(.context != "tide" and .name != "tide" and (.state == "FAILURE" or .conclusion == "FAILURE"))] | length == 0) and
-              ([.statusCheckRollup[] | select(.context != "tide" and .name != "tide" and (.state == "SUCCESS" or .conclusion == "SUCCESS"))] | length > 0)
+              ([.statusCheckRollup[] | select(.context != "tide" and .name != "tide")] as $checks |
+                ($checks | length > 0) and
+                ($checks | all(.state == "SUCCESS" or .conclusion == "SUCCESS")))
             )')
 
           if [ -z "$prs" ]; then
@@ -49,7 +55,11 @@ jobs:
       - name: Auto-merge ready PRs
         if: steps.get_prs.outputs.ready_prs != '[]'
         run: |
-          ready_prs='${{ steps.get_prs.outputs.ready_prs }}'
+          # Read the PR list from an environment variable rather than
+          # interpolating it directly into the script, since it contains
+          # contributor-controlled PR titles that could otherwise break out
+          # of the quoted assignment and inject shell commands.
+          ready_prs="$READY_PRS"
 
           echo "Processing PRs for auto-merge..."
           echo "$ready_prs" | jq -r '.[] | .number' | while read -r pr_number; do
@@ -58,11 +68,14 @@ jobs:
             pr_info=$(echo "$ready_prs" | jq -r ".[] | select(.number == $pr_number)")
             pr_title=$(echo "$pr_info" | jq -r '.title')
             pr_branch=$(echo "$pr_info" | jq -r '.headRefName')
+            pr_head_oid=$(echo "$pr_info" | jq -r '.headRefOid')
 
             echo "Attempting to merge PR #$pr_number: $pr_title (branch: $pr_branch)"
 
-            # Attempt to merge the PR
-            if gh pr merge "$pr_number" --squash --delete-branch; then
+            # --match-head-commit binds the merge to the exact commit that
+            # was evaluated for eligibility, so a push landing between the
+            # eligibility check and this merge cannot slip in unreviewed.
+            if gh pr merge "$pr_number" --squash --delete-branch --match-head-commit "$pr_head_oid"; then
               echo "Successfully merged PR #$pr_number"
 
               gh pr comment "$pr_number" --body "This PR was automatically merged because all checks passed and it matched the trusted dependency update pattern (author: jnpacker, branch: $pr_branch)."
@@ -76,6 +89,7 @@ jobs:
           done
         env:
           GH_TOKEN: ${{ github.token }}
+          READY_PRS: ${{ steps.get_prs.outputs.ready_prs }}
 
       - name: Summary
         run: |

--- a/.github/workflows/auto-merge-deps.yaml
+++ b/.github/workflows/auto-merge-deps.yaml
@@ -1,0 +1,86 @@
+name: Auto-merge Dependency Updates
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every 30 min, 13:30-17:00 UTC, Mon-Fri.
+    # Covers 9:30am-12pm ET across both EDT (UTC-4) and EST (UTC-5), since
+    # GitHub Actions cron is UTC-only and does not observe DST.
+    - cron: "30 13 * * 1-5" # 13:30 UTC
+    - cron: "0,30 14-16 * * 1-5" # 14:00, 14:30, 15:00, 15:30, 16:00, 16:30 UTC
+    - cron: "0 17 * * 1-5" # 17:00 UTC
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Get eligible dependency PRs
+        id: get_prs
+        run: |
+          # Only PRs authored by the trusted jnpacker PAT identity, on a
+          # dependency-update branch (created by the swarm-deps-agent bot),
+          # are eligible for auto-merge. Also require the PR to be mergeable
+          # and all non-tide checks to have passed.
+          prs=$(gh pr list --state open --json number,title,url,author,headRefName,statusCheckRollup,mergeable --jq '
+            .[] | select(
+              (.author.login == "jnpacker") and
+              (.headRefName | test("^(fix|build)/(go|python)-deps-")) and
+              (.mergeable == "MERGEABLE") and
+              ([.statusCheckRollup[] | select(.context != "tide" and .name != "tide" and (.state == "FAILURE" or .conclusion == "FAILURE"))] | length == 0) and
+              ([.statusCheckRollup[] | select(.context != "tide" and .name != "tide" and (.state == "SUCCESS" or .conclusion == "SUCCESS"))] | length > 0)
+            )')
+
+          if [ -z "$prs" ]; then
+            echo "No PRs ready for auto-merge"
+            echo "ready_prs=[]" >> "$GITHUB_OUTPUT"
+          else
+            echo "Found PRs ready for auto-merge:"
+            echo "$prs" | jq -r '.number'
+            echo "ready_prs<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$prs" | jq -s '.' >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Auto-merge ready PRs
+        if: steps.get_prs.outputs.ready_prs != '[]'
+        run: |
+          ready_prs='${{ steps.get_prs.outputs.ready_prs }}'
+
+          echo "Processing PRs for auto-merge..."
+          echo "$ready_prs" | jq -r '.[] | .number' | while read -r pr_number; do
+            echo "Processing PR #$pr_number"
+
+            pr_info=$(echo "$ready_prs" | jq -r ".[] | select(.number == $pr_number)")
+            pr_title=$(echo "$pr_info" | jq -r '.title')
+            pr_branch=$(echo "$pr_info" | jq -r '.headRefName')
+
+            echo "Attempting to merge PR #$pr_number: $pr_title (branch: $pr_branch)"
+
+            # Attempt to merge the PR
+            if gh pr merge "$pr_number" --squash --delete-branch; then
+              echo "Successfully merged PR #$pr_number"
+
+              gh pr comment "$pr_number" --body "This PR was automatically merged because all checks passed and it matched the trusted dependency update pattern (author: jnpacker, branch: $pr_branch)."
+            else
+              echo "Failed to merge PR #$pr_number"
+
+              gh pr comment "$pr_number" --body "Auto-merge failed for this PR. Please check for conflicts or other issues."
+            fi
+
+            echo "---"
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Summary
+        run: |
+          echo "Auto-merge workflow completed"
+          echo "Checked for dependency PRs authored by jnpacker on branches matching"
+          echo "fix/{go,python}-deps-* or build/{go,python}-deps-* that have:"
+          echo "- All status checks passing (SUCCESS)"
+          echo "- Mergeable state (no conflicts)"


### PR DESCRIPTION
## Executive Summary

- Adds `.github/workflows/auto-merge-deps.yaml` to automatically squash-merge trusted dependency/CVE-fix PRs opened by the repo's `swarm-deps-agent` automation, once all checks pass.
- Since the bot pushes via the `jnpacker` PAT (same GitHub author as manually created PRs), trust is established via **PR author (`jnpacker`) + branch naming convention** (`(fix|build)/(go|python)-deps-*`) rather than a distinct bot identity.
- Runs every 30 min from 13:30-17:00 UTC, Mon-Fri (covers 9:30am-12pm ET across both EDT and EST, since GitHub Actions cron is UTC-only) plus manual `workflow_dispatch`.

## Detailed Implementation Summary

**New file:** `.github/workflows/auto-merge-deps.yaml`

**Trigger:**
- `workflow_dispatch` (manual)
- `schedule`: three cron entries covering 13:30, 14:00-16:30 (every 30 min), and 17:00 UTC, Mon-Fri — equivalent to every 30 minutes from 13:30-17:00 UTC

**Eligibility filter (all must match):**
- `author.login == "jnpacker"`
- `headRefName` matches `^(fix|build)/(go|python)-deps-`
- `mergeable == "MERGEABLE"`
- All non-`tide` status checks passed (zero `FAILURE`, at least one `SUCCESS`)

**Trust model rationale:**
- Adapted from `stolostron/konflux-build-catalog`'s `auto-merge-automated-updates.yaml`, which filters by GitHub App author login (`app/github-actions`, `app/acm-agent`).
- This repo's bot pushes via a personal access token belonging to `jnpacker`, so every PR — bot or manual — has the same author. The branch-prefix condition compensates: fork PRs can't create branches in this repo, and only push-access holders can create branches matching the naming convention.
- **Rejected approach:** filtering by git commit author/committer name (e.g. `swarm-deps-agent`) was considered and explicitly rejected, since git author metadata is self-reported and trivially forgeable (`git config user.name`) — it provides no real security guarantee.

**On match:** squash-merge with `--delete-branch`, then comment on the PR noting the auto-merge reason.
**On failure:** comment on the PR noting the failure.

**Tests / verification:**
- YAML validated locally (`python3 -c "import yaml; yaml.safe_load(...)"`) — passes
- Not yet exercised against a live PR; first scheduled/manual run should be monitored to confirm correct behavior

**Known follow-ups:**
- No CI check yet validates this workflow itself (e.g. actionlint) — could be added to `ci.yml` in a follow-up
- First scheduled run should be spot-checked to confirm it correctly merges an eligible PR and skips ineligible ones

## Jira

[FLD-121](https://redhat.atlassian.net/browse/FLD-121)

## Checklist

- [x] Workflow YAML is valid
- [x] Manual trigger (`workflow_dispatch`) available for on-demand testing
- [ ] First scheduled/manual run verified against a live PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated processing for eligible dependency updates during scheduled maintenance windows.
  * Qualifying updates can now be merged automatically after required checks pass.
  * Completed or unsuccessful processing is reported directly on the relevant change request.
  * Merged updates are cleaned up automatically to keep the project current and reduce manual maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->