### PR TITLE
fix(deps): resolve security vulnerabilities in Go dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module gcal-mcp-server
 
 go 1.26.3
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	golang.org/x/oauth2 v0.36.0


### PR DESCRIPTION
## Security audit summary

### CVEs resolved
| ID | Module | Severity | Fixed in |
|----|--------|----------|----------|
| GO-2026-6218 | stdlib (net/url) | Medium | go1.26.6 |
| GO-2026-6091 | stdlib (html/template) | Medium | go1.26.6 |
| GO-2026-6090 | stdlib (crypto/tls) | Medium | go1.26.6 |
| GO-2026-6089 | stdlib (net/http) | Medium | go1.26.6 |
| GO-2026-5972 | stdlib (encoding/asn1) | Medium | go1.26.6 |
| GO-2026-5026 | stdlib (golang.org/x/net/idna via net/http) | Medium | go1.26.6 |
| GO-2026-6088 | stdlib (encoding/xml) | Medium | go1.26.6 |
| GO-2026-5942 | stdlib (net, dns/dnsmessage) | Medium | go1.26.6 |

All of the above are Go standard library vulnerabilities fixed by the go1.26.6 toolchain release. No third-party module upgrade was required.

### Unresolved (no fix available)
- GO-2026-5932 — golang.org/x/crypto/openpgp is unmaintained and has no fixed version. Our code does not import or call this package (confirmed via `go mod why golang.org/x/crypto`: not even a direct dependency), so no code change was made. No inline TODO was added since there is no import site in this repo.

### Modules changed
- go.mod: `toolchain` bumped from `go1.26.5` → `go1.26.6` (resolves all called stdlib CVEs above)

### Verification
- [x] govulncheck: clean (0 vulnerabilities in code; 1 unfixable, uncalled transitive finding documented above)
- [x] go build ./...: passing
- [x] golangci-lint run ./...: passing (0 issues)
- [x] go test ./...: passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s Go toolchain version to 1.26.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->